### PR TITLE
[FIX] 정적 리소스 EncodingFilter 적용 문제 수정

### DIFF
--- a/src/main/java/config/EncodingFilter.java
+++ b/src/main/java/config/EncodingFilter.java
@@ -11,53 +11,55 @@ import javax.servlet.ServletResponse;
 import javax.servlet.annotation.WebFilter;
 import javax.servlet.annotation.WebInitParam;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
-/**
- * UTF-8 인코딩 필터
- * @WebFilter로 자동 등록
- */
-@WebFilter(
-    filterName = "encodingFilter",
-    urlPatterns = {"/*"}, 
-    initParams = {
-        @WebInitParam(name = "encoding", value = "UTF-8")
-    }
-)
+@WebFilter(filterName = "encodingFilter", urlPatterns = {"/*"}, initParams = {
+	@WebInitParam(name = "encoding", value = "UTF-8")})
 public class EncodingFilter implements Filter {
 
-    private String encoding = "UTF-8";
+	private String encoding = "UTF-8";
 
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
-        // web.xml에서 설정한 인코딩 값 가져오기
-        String encodingParam = filterConfig.getInitParameter("encoding");
-        if (encodingParam != null && !encodingParam.isEmpty()) {
-            this.encoding = encodingParam;
-        }
-        System.out.println("[EncodingFilter] 초기화 완료 - 인코딩: " + this.encoding);
-    }
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		String encodingParam = filterConfig.getInitParameter("encoding");
+		if (encodingParam != null && !encodingParam.isEmpty()) {
+			this.encoding = encodingParam;
+		}
+		System.out.println("[EncodingFilter] 초기화 완료 - 인코딩: " + this.encoding);
+	}
 
-    @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-            throws IOException, ServletException {
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+		throws IOException, ServletException {
 
-        HttpServletRequest httpRequest = (HttpServletRequest) request;
+		HttpServletRequest req = (HttpServletRequest)request;
+		HttpServletResponse res = (HttpServletResponse)response;
 
-        // 요청 인코딩 설정
-        if (request.getCharacterEncoding() == null) {
-            request.setCharacterEncoding(encoding);
-        }
+		if (req.getCharacterEncoding() == null) {
+			req.setCharacterEncoding(encoding);
+		}
+		res.setCharacterEncoding(encoding);
 
-        // 응답 인코딩 설정
-        response.setCharacterEncoding(encoding);
-        response.setContentType("text/html; charset=" + encoding);
+		String uri = req.getRequestURI();
+		String ctx = req.getContextPath();
 
-        // 다음 필터 또는 서블릿으로 전달
-        chain.doFilter(request, response);
-    }
+		// 정적 리소스 여부 확인 (제외 필요)
+		boolean isStaticResource = uri.startsWith(ctx + "/static/")
+			|| uri.matches(".*\\.(css|js|png|jpg|jpeg|gif|svg|ico|woff|woff2|map)$");
 
-    @Override
-    public void destroy() {
-        System.out.println("[EncodingFilter] 종료");
-    }
+		if (!isStaticResource) {
+			if (req.getCharacterEncoding() == null) {
+				req.setCharacterEncoding(encoding);
+			}
+			res.setCharacterEncoding(encoding);
+			res.setContentType("text/html; charset=" + encoding);
+		}
+
+		chain.doFilter(request, response);
+	}
+
+	@Override
+	public void destroy() {
+		System.out.println("[EncodingFilter] 종료");
+	}
 }


### PR DESCRIPTION
## 📌 작업 내용

EncodingFilter가 모든 요청에 대해 Content-Type: text/html을 강제로 설정하고 있어 정적 리소스까지 HTML로 응답되던 문제를 해결하였습니다.

- 정적 리소스(/static/**, css 등의 확장자)를 EncodingFilter 적용 대상에서 제외하였습니다.
- JSP/Servlet 응답에 대해서만 인코딩 처리가 적용되도록 필터의 적용 범위를 제한하였습니다.

<br>

## 🔗 관련 이슈

- closes #26 

<br>


## 👀 리뷰 시 참고사항

- 다음 작업과 연관된 사항이라 빠르게 확인해주시면 감사하겠습니다🙇‍♀️

<br>

## 💭 느낀 점

- 필터는 모든 요청에 공통으로 적용되기 때문에, 적용 범위를 명확히 설계하는 것이 중요하다는 점을 느꼈습니다.
- Network 탭을 통해 응답 헤더를 확인하는 과정에서 문제를 해결할 수 있었습니다.

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 정적 리소스 처리 시 불필요한 인코딩 재적용 제거로 성능 최적화
* 동적 콘텐츠의 문자 인코딩 처리 일관성 강화
* 응답 인코딩 및 콘텐츠 타입 설정 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->