### PR TITLE
[FEAT] 대기&게임 채팅 구현

### DIFF
--- a/src/main/java/chat/webSocket/ChatServer.java
+++ b/src/main/java/chat/webSocket/ChatServer.java
@@ -1,0 +1,150 @@
+package chat.webSocket;
+
+import javax.websocket.*;
+import javax.websocket.server.PathParam;
+import javax.websocket.server.ServerEndpoint;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+@ServerEndpoint("/ws/room/{roomId}")
+public class ChatServer {
+
+    // roomId -> sessions
+    private static final ConcurrentHashMap<String, CopyOnWriteArraySet<Session>> rooms = new ConcurrentHashMap<>();
+
+    // sessionId -> playerNo (1,2,3...)
+    private static final ConcurrentHashMap<String, Integer> playerNoMap = new ConcurrentHashMap<>();
+
+    // roomId -> state ("LOBBY" or "IN_GAME")
+    private static final ConcurrentHashMap<String, String> roomState = new ConcurrentHashMap<>();
+
+    private static final int GAME_START_PLAYERS = 2; // 개인전: 2명 되면 시작 (팀전이면 4로 바꾸면 됨)
+
+    @OnOpen
+    public void onOpen(Session session, @PathParam("roomId") String roomId) throws IOException {
+        CopyOnWriteArraySet<Session> set =
+                rooms.computeIfAbsent(roomId, k -> new CopyOnWriteArraySet<>());
+        set.add(session);
+
+        // 플레이어 번호 부여(테스트용 하드코딩)
+        int playerNo = set.size(); // 들어온 순서대로 1,2,3...
+        playerNoMap.put(session.getId(), playerNo);
+
+        // 나중에 카카오 로그인 닉네임을 쓰려면
+        // 1) HttpSession을 EndpointConfig로 가져오는 Configurator가 필요하고
+        // 2) 여기서 nickname을 session.getUserProperties()에 저장하는 방식으로 씀
+        // String nickname = (String) httpSession.getAttribute("nickname");
+        // session.getUserProperties().put("nickname", nickname);
+
+        // 접속 확인 메시지
+        send(session, "SYSTEM:connected room=" + roomId);
+
+        // 현재 상태 계산/전파
+        updateAndBroadcastState(roomId);
+
+        // 참가 메시지
+        broadcast(roomId, "SYSTEM:Player" + playerNo + " joined (players=" + set.size() + ")");
+    }
+
+    @OnMessage
+    public void onMessage(Session session, String message, @PathParam("roomId") String roomId) {
+        String state = roomState.getOrDefault(roomId, "LOBBY");
+        int playerNo = playerNoMap.getOrDefault(session.getId(), 0);
+        String nick = "Player" + playerNo;
+
+        // message 
+        if (message == null) return;
+
+        // 게임 시작 후에는 이모지만 허용(채팅 막기)
+        if ("IN_GAME".equals(state)) {
+            if (message.startsWith("EMOJI:")) {
+                String code = message.substring("EMOJI:".length());
+                broadcast(roomId, "EMOJI:" + nick + ":" + code);
+            } else {
+                // 게임 중 채팅은 무시(또는 경고 SYSTEM 메시지로 보내도 됨)
+                send(session, "SYSTEM:IN_GAME mode - only EMOJI allowed");
+            }
+            return;
+        }
+
+        // LOBBY에서는 채팅만(이모지도 보내고 싶으면 허용해도 됨)
+        if (message.startsWith("CHAT:")) {
+            String text = message.substring("CHAT:".length());
+            broadcast(roomId, "CHAT:" + nick + ":" + text);
+        } else if (message.startsWith("EMOJI:")) {
+            // 로비에서도 이모지 허용하고 싶으면 살려두기
+            String code = message.substring("EMOJI:".length());
+            broadcast(roomId, "EMOJI:" + nick + ":" + code);
+        } else {
+            // 알 수 없는 프로토콜
+            send(session, "SYSTEM:Unknown message format");
+        }
+    }
+
+    @OnClose
+    public void onClose(Session session, @PathParam("roomId") String roomId) {
+        CopyOnWriteArraySet<Session> set = rooms.get(roomId);
+        if (set != null) {
+            set.remove(session);
+        }
+
+        Integer playerNo = playerNoMap.remove(session.getId());
+        String nick = (playerNo == null) ? "Unknown" : ("Player" + playerNo);
+
+        // 나간 메시지
+        int players = (set == null) ? 0 : set.size();
+        broadcast(roomId, "SYSTEM:" + nick + " left (players=" + players + ")");
+
+        // 상태 갱신/전파
+        updateAndBroadcastState(roomId);
+
+        // 방 비면 정리
+        if (set != null && set.isEmpty()) {
+            rooms.remove(roomId);
+            roomState.remove(roomId);
+        }
+    }
+
+    private static void updateAndBroadcastState(String roomId) {
+        CopyOnWriteArraySet<Session> set = rooms.get(roomId);
+        int players = (set == null) ? 0 : set.size();
+
+        String newState = (players >= GAME_START_PLAYERS) ? "IN_GAME" : "LOBBY";
+        String oldState = roomState.getOrDefault(roomId, "LOBBY");
+
+        roomState.put(roomId, newState);
+
+        // 상태가 바뀐 경우만 브로드캐스트
+        if (!newState.equals(oldState)) {
+            broadcast(roomId, "STATE:" + newState);
+        } else {
+            // 디버깅용으로 처음 접속자에게도 상태를 알리고 싶으면 아래처럼 유지해도 됨
+            // 지금은 gameChat에서 LOBBY 받으면 방으로 돌아가니까, 상태 바뀔 때만이 안정적
+            // broadcast(roomId, "STATE:" + newState);
+        }
+    }
+
+    private static void broadcast(String roomId, String msg) {
+        CopyOnWriteArraySet<Session> set = rooms.get(roomId);
+        if (set == null) return;
+
+        for (Session s : set) {
+            if (!s.isOpen()) continue;
+            try {
+                s.getBasicRemote().sendText(msg);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static void send(Session s, String msg) {
+        if (s == null || !s.isOpen()) return;
+        try {
+            s.getBasicRemote().sendText(msg);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/chat/webSocket/ChatServerWebSocket.java
+++ b/src/main/java/chat/webSocket/ChatServerWebSocket.java
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 @ServerEndpoint("/ws/room/{roomId}")
-public class ChatServer {
+public class ChatServerWebSocket {
 
     // roomId -> sessions
     private static final ConcurrentHashMap<String, CopyOnWriteArraySet<Session>> rooms = new ConcurrentHashMap<>();

--- a/src/main/webapp/gameChat.jsp
+++ b/src/main/webapp/gameChat.jsp
@@ -1,0 +1,69 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>게임 중</title>
+    <style>
+    
+        .players { display: flex; gap: 16px; margin: 16px 0; }
+        .player {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            border: 1px solid #ccc;
+            padding: 10px;
+            border-radius: 10px;
+            min-width: 180px;
+        }
+        .avatar { width: 40px; height: 40px; border-radius: 50%; background: #eee; }
+        .name { font-weight: bold; }
+        .bubble {
+            display: none;
+            margin-left: 6px;
+            padding: 6px 10px;
+            border: 1px solid #aaa;
+            border-radius: 14px;
+            background: #fff;
+        }
+        .emojiBar { margin-top: 16px; }
+        .emojiBar button { font-size: 18px; margin-right: 8px; }
+    </style>
+</head>
+<body>
+
+<h2>게임 중 (이모지 전용)</h2>
+
+<div class="players">
+    <!-- data-user를 서버 닉네임과 동일하게 -->
+    <div class="player" data-user="Player1">
+        <div class="avatar"></div>
+        <div><div class="name">Player1</div></div>
+        <div class="bubble"></div>
+    </div>
+
+    <div class="player" data-user="Player2">
+        <div class="avatar"></div>
+        <div><div class="name">Player2</div></div>
+        <div class="bubble"></div>
+    </div>
+</div>
+
+<div class="emojiBar">
+    <button onclick="sendEmoji('smile')">🙂</button>
+    <button onclick="sendEmoji('angry')">😡</button>
+    <button onclick="sendEmoji('clap')">👏</button>
+</div>
+
+<script>
+    window.contextPath = "<%= request.getContextPath() %>";
+    const params = new URLSearchParams(location.search);
+    window.roomId = params.get("roomId") || "lobby";
+</script>
+
+<!-- ws-common 먼저 실행  --> 
+<script src="<%= request.getContextPath() %>/js/ws-common.js"></script>
+<script src="<%= request.getContextPath() %>/js/game.js"></script>
+
+</body>
+</html>

--- a/src/main/webapp/js/game.js
+++ b/src/main/webapp/js/game.js
@@ -1,0 +1,62 @@
+(function initGameChat() {
+  if (typeof contextPath === "undefined" || !contextPath) {
+    window.contextPath = "/" + location.pathname.split("/")[1];
+  }
+  if (typeof roomId === "undefined" || !roomId) {
+    const params = new URLSearchParams(location.search);
+    window.roomId = params.get("roomId") || "lobby";
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    connectWs(window.contextPath, window.roomId);
+  });
+})();
+
+function sendEmoji(code) {
+  sendWs("EMOJI:" + code);
+}
+
+function onWsMessage(msg) {
+  if (msg.indexOf("EMOJI:") === 0) {
+    const parts = msg.split(":");
+    const nick = (parts.length > 1 && parts[1] != null) ? parts[1] : "";
+    const code = (parts.length > 2 && parts[2] != null) ? parts[2] : "";
+    showBubble(nick, emojiToChar(code));
+    return;
+  }
+
+  // 게임 중에는 채팅 표시 안 함
+  console.log("GAME MSG:", msg);
+}
+
+function onStateMessage(phase) {
+  // 사람이 줄어서 다시 대기실 상태가 되면 방으로 돌아감
+  if (phase === "LOBBY") {
+    location.href =
+      window.contextPath +
+      "/roomChat.jsp?roomId=" +
+      encodeURIComponent(window.roomId);
+  }
+}
+
+function emojiToChar(code) {
+  const map = { smile: "🙂", angry: "😡", clap: "👏" };
+  return map[code] || "🙂";
+}
+
+function showBubble(nick, emojiChar) {
+  // gameChat.jsp에서 data-user="Player1", "Player2" 로 맞추면 정확히 매칭됨
+  let bubble = document.querySelector("[data-user='" + nick.replace(/'/g, "\\'") + "'] .bubble");
+
+  // 못 찾으면 첫번째 플레이어에 표시
+  if (!bubble) bubble = document.querySelector(".player .bubble");
+  if (!bubble) return;
+
+  bubble.innerText = emojiChar;
+  bubble.style.display = "inline-block";
+
+  // 너무 빨리 사라지면 2500ms 정도로 
+  setTimeout(function () {
+    bubble.style.display = "none";
+  }, 2500);
+}

--- a/src/main/webapp/js/room.js
+++ b/src/main/webapp/js/room.js
@@ -1,0 +1,68 @@
+(function initRoomChat() {
+  if (typeof contextPath === "undefined" || !contextPath) {
+    window.contextPath = "/" + location.pathname.split("/")[1];
+  }
+
+  if (typeof roomId === "undefined" || !roomId) {
+    const params = new URLSearchParams(location.search);
+    window.roomId = params.get("roomId") || "lobby";
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    connectWs(window.contextPath, window.roomId);
+
+    const input = document.querySelector(".content");
+    if (input) {
+      input.addEventListener("keydown", function (e) {
+        if (e.key === "Enter") {
+			e.preventDefault();
+			sendChat();
+			}
+      });
+    }
+  });
+})();
+
+function sendChat() {
+  const input = document.querySelector(".content");
+  if (!input) return;
+
+  const text = input.value.trim();
+  if (text.length === 0) return;
+
+  sendWs("CHAT:" + text);
+  input.value = "";
+}
+
+function onWsMessage(msg) {
+  if (msg.indexOf("CHAT:") === 0) {
+    const parts = msg.split(":");
+    const nick = (parts.length > 1 && parts[1] != null) ? parts[1] : "";
+    const text = (parts.length > 2) ? parts.slice(2).join(":") : "";
+    appendLine(nick + " : " + text);
+    return;
+  }
+
+  // SYSTEM / EMOJI 등은 일단 그대로 출력
+  appendLine(msg);
+}
+
+function onStateMessage(phase) {
+  // 2명 이상 되면(개인전 기준) 서버가 STATE:IN_GAME을 쏴줌 → 게임 화면으로 이동
+  if (phase === "IN_GAME") {
+    location.href =
+      window.contextPath +
+      "/gameChat.jsp?roomId=" +
+      encodeURIComponent(window.roomId);
+  }
+}
+
+function appendLine(text) {
+  const box = document.querySelector(".msgArea");
+  if (!box) return;
+
+  const div = document.createElement("div");
+  div.innerText = text;
+  box.appendChild(div);
+  box.scrollTop = box.scrollHeight;
+}

--- a/src/main/webapp/js/ws-common.js
+++ b/src/main/webapp/js/ws-common.js
@@ -1,0 +1,45 @@
+// roomChat.jsp / gameChat.jsp 공용
+let socket = null;
+
+function connectWs(contextPath, roomId) {
+  if (socket && socket.readyState === WebSocket.OPEN) return;
+
+  const wsUrl =
+    "ws://" + location.host + contextPath + "/ws/room/" + encodeURIComponent(roomId);
+
+  console.log("WebSocket URL =", wsUrl);
+  socket = new WebSocket(wsUrl);
+
+  socket.onopen = function () {
+    console.log("WebSocket 연결 성공");
+  };
+
+  socket.onerror = function (e) {
+    console.error("WebSocket 오류", e);
+  };
+
+  socket.onclose = function () {
+    console.log("WebSocket 연결 종료");
+  };
+
+  socket.onmessage = function (e) {
+    const msg = e.data;
+    console.log("수신:", msg);
+
+    if (msg.startsWith("STATE:")) {
+      const phase = msg.substring("STATE:".length).trim();
+      if (typeof onStateMessage === "function") onStateMessage(phase);
+      return;
+    }
+
+    if (typeof onWsMessage === "function") onWsMessage(msg);
+  };
+}
+
+function sendWs(msg) {
+  if (!socket || socket.readyState !== WebSocket.OPEN) {
+    alert("WebSocket이 연결되어 있지 않습니다.");
+    return;
+  }
+  socket.send(msg);
+}

--- a/src/main/webapp/roomChat.jsp
+++ b/src/main/webapp/roomChat.jsp
@@ -1,0 +1,37 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>대기실</title>
+    <style>
+        .msgArea {
+            border: 1px solid #ccc;
+            width: 420px;
+            height: 260px;
+            overflow-y: auto;
+            padding: 8px;
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+
+<h2>대기실 채팅</h2>
+
+<div class="msgArea"></div>
+<input type="text" class="content" placeholder="메시지 입력">
+<button onclick="sendChat()">보내기</button>
+
+<script>
+    // 전역(window)에 박아두기 (room.js에서 사용)
+    window.contextPath = "<%= request.getContextPath() %>";
+    const params = new URLSearchParams(location.search);
+    window.roomId = params.get("roomId") || "lobby";
+</script>
+
+<script src="<%= request.getContextPath() %>/js/ws-common.js"></script>
+<script src="<%= request.getContextPath() %>/js/room.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
## 📌 작업 내용

- WebSocket 기반 방 단위 채팅 서버 구현 (`/ws/room/{roomId}`)
- 대기방(LOBBY) / 게임방(IN_GAME) 상태 분리 및 전환 로직 추가
- 방 단위 세션 관리 및 플레이어 번호 할당
- 게임 중 채팅 제한 (텍스트 차단, 이모지 전송만 허용)
- 대기방 / 게임방 채팅 JSP 화면 추가
- WebSocket 프론트엔드 스크립트 분리 및 연동
- ChatServer → ChatServerWebSocket 클래스명 리팩토링

<br>

## 🔗 관련 이슈

- closes #12 

<br>

## 👀 리뷰 시 참고사항

- 방 단위 세션 관리 구조가 적절한지
- LOBBY → IN_GAME 상태 전환 시점 로직
- WebSocket 서버 로직과 JSP / JS 분리 구조에 대한 피드백 


<br>

## 💭 느낀 점

- 채팅 상태(대기/게임)에 따라 기능을 제한하는 로직이 생각보다 복잡했음
- 현재 코드는 대기 채팅에서 게임 중 채팅으로 새 소켓을 여는 구조 -> 착수 순서나 팀 배정을 저장할 수 없음
- 한 소켓으로 대기 채팅, 오목 플레이, 게임 중 채팅이 자연스럽게 전환될 수 있도록 수정 필요

<br>

## 💻 스크린샷 (선택)

<img width="530" height="219" alt="image (1)" src="https://github.com/user-attachments/assets/9e302475-c067-4b09-874c-ecd346c27950" />
<img width="484" height="394" alt="image" src="https://github.com/user-attachments/assets/76a7139e-c066-4577-93ae-8d9d0182de27" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added real-time chat messaging for game rooms and lobbies
* Introduced emoji-based communication during gameplay with visual feedback
* Implemented player identification for chat messages and emoji exchanges
* Added automatic chat interface transitions between pre-game and in-game states

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->