### PR TITLE
[FEAT]  게임 시작 시 대기방 → 게임 화면 WS 기반 리다이렉트

### DIFF
--- a/src/main/java/game/controller/GameStartController.java
+++ b/src/main/java/game/controller/GameStartController.java
@@ -1,0 +1,78 @@
+package game.controller;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import room.dao.RoomDAO;
+import room.dao.RoomDAOImpl;
+import room.dao.RoomPlayerDAO;
+import room.dao.RoomPlayerDAOImpl;
+
+@WebServlet("/game/start")
+public class GameStartController extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+
+	private final RoomDAO roomDao = new RoomDAOImpl();
+	private final RoomPlayerDAO roomPlayerDao = new RoomPlayerDAOImpl();
+
+	@Override
+	protected void doPost(HttpServletRequest request, HttpServletResponse response)
+		throws ServletException, IOException {
+
+		HttpSession session = request.getSession(false);
+		String loginUserId = (session == null) ? null : (String)session.getAttribute("loginUserId");
+
+		if (loginUserId == null) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그인이 필요합니다.");
+			return;
+		}
+
+		String roomId = request.getParameter("roomId");
+		String playType = request.getParameter("playType");
+
+		if (roomId == null || roomId.isBlank() || playType == null || playType.isBlank()) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "roomId와 playType이 필요합니다.");
+			return;
+		}
+
+		try {
+			String hostUserId = roomDao.getHostUserId(roomId);
+
+			if (hostUserId == null) {
+				response.sendError(HttpServletResponse.SC_NOT_FOUND, "존재하지 않는 방입니다.");
+				return;
+			}
+
+			if (!loginUserId.equals(hostUserId)) {
+				response.sendError(HttpServletResponse.SC_FORBIDDEN, "게임 시작 권한이 없습니다. (host만 가능)");
+				return;
+			}
+
+			int updated = roomPlayerDao.updatePlayersToInGame(roomId);
+
+			System.out.println("[GameStart] roomId=" + roomId + " updatedPlayers=" + updated);
+			System.out.println(request.getContextPath() + "/game/single.jsp");
+			if ("0".equals(playType)) {
+				response.sendRedirect(
+					request.getContextPath() + "/game/single?roomId="
+						+ URLEncoder.encode(roomId, StandardCharsets.UTF_8));
+			} else if ("1".equals(playType)) {
+				response.sendRedirect(
+					request.getContextPath() + "/game/multi?roomId="
+						+ URLEncoder.encode(roomId, StandardCharsets.UTF_8));
+			}
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "게임 시작 처리 중 오류가 발생했습니다.");
+		}
+	}
+}

--- a/src/main/java/room/controller/EnterRoomController.java
+++ b/src/main/java/room/controller/EnterRoomController.java
@@ -29,7 +29,8 @@ public class EnterRoomController extends HttpServlet {
 
 		try {
 			String roomId = request.getParameter("roomId");
-			if (roomId == null || roomId.isBlank()) {
+			String playType = request.getParameter("playType");
+			if (roomId == null || roomId.isBlank() || playType == null || playType.isBlank()) {
 				response.sendRedirect(ctx + "/lobby?error=missing_room_id");
 				return;
 			}
@@ -45,7 +46,9 @@ public class EnterRoomController extends HttpServlet {
 
 			System.out.println("[ENTER] ctx=" + request.getContextPath() + " roomId=" + roomId + " userId=" + userId);
 			LobbyWebSocket.broadcastRoomList();
-			response.sendRedirect(ctx + "/room?roomId=" + URLEncoder.encode(roomId, StandardCharsets.UTF_8));
+			response
+				.sendRedirect(ctx + "/room?roomId=" + URLEncoder.encode(roomId, StandardCharsets.UTF_8) + "&playType="
+					+ URLEncoder.encode(playType, StandardCharsets.UTF_8));
 		} catch (Exception e) {
 			e.printStackTrace();
 			response.sendRedirect(ctx + "/lobby?error=enter_failed");

--- a/src/main/java/room/controller/ViewRoomController.java
+++ b/src/main/java/room/controller/ViewRoomController.java
@@ -17,6 +17,7 @@ public class ViewRoomController extends HttpServlet {
 		throws ServletException, IOException {
 		try {
 			String roomId = request.getParameter("roomId");
+			String playType = request.getParameter("playType");
 
 			if (roomId == null) {
 				response.sendRedirect("/lobby");
@@ -24,6 +25,7 @@ public class ViewRoomController extends HttpServlet {
 			}
 
 			request.setAttribute("roomId", roomId);
+			request.setAttribute("playType", playType);
 
 			request.getRequestDispatcher("/WEB-INF/views/room.jsp").forward(request, response);
 			return;

--- a/src/main/java/room/dao/RoomDAO.java
+++ b/src/main/java/room/dao/RoomDAO.java
@@ -15,4 +15,11 @@ public interface RoomDAO {
 		String isPublic,
 		String playType) throws Exception;
 
+	/**
+	 * 방의 host userId 조회
+	 * @param roomId 방 ID
+	 * @return host userId (없으면 null)
+	 */
+	String getHostUserId(String roomId) throws Exception;
+
 }

--- a/src/main/java/room/dao/RoomDAOImpl.java
+++ b/src/main/java/room/dao/RoomDAOImpl.java
@@ -91,6 +91,29 @@ public class RoomDAOImpl implements RoomDAO {
 			.build();
 	}
 
+	@Override
+	public String getHostUserId(String roomId) throws Exception {
+
+		String sql = """
+				SELECT host_user_id
+				FROM room
+				WHERE id = ?
+			""";
+
+		try (Connection conn = DB.getConnection();
+			PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+			pstmt.setString(1, roomId);
+
+			try (ResultSet rs = pstmt.executeQuery()) {
+				if (rs.next()) {
+					return rs.getString("host_user_id");
+				}
+				return null;
+			}
+		}
+	}
+
 	private RoomDTO mapToRoom(ResultSet rs) throws SQLException {
 		return RoomDTO.builder()
 			.id(rs.getString("id"))

--- a/src/main/java/room/dao/RoomPlayerDAO.java
+++ b/src/main/java/room/dao/RoomPlayerDAO.java
@@ -14,4 +14,11 @@ public interface RoomPlayerDAO {
 
 	public int countActivePlayers(String roomId) throws Exception;
 
+	/**
+	 * 게임 시작 시 방에 있는 플레이어 상태를 IN_GAME(1)으로 변경
+	 * @param roomId 방 ID
+	 * @return 변경된 행 수
+	 */
+	int updatePlayersToInGame(String roomId) throws Exception;
+
 }

--- a/src/main/java/room/dao/RoomPlayerDAOImpl.java
+++ b/src/main/java/room/dao/RoomPlayerDAOImpl.java
@@ -13,6 +13,7 @@ import util.DB;
 public class RoomPlayerDAOImpl implements RoomPlayerDAO {
 
 	private static final String STATUS_IN_ROOM = "0"; // 입장
+	private static final String STATUS_IN_GAME = "1"; // 게임 중
 	private static final String STATUS_LEAVE = "2"; // 퇴장
 
 	@Override
@@ -167,6 +168,27 @@ public class RoomPlayerDAOImpl implements RoomPlayerDAO {
 					return rs.getInt("CNT");
 				return 0;
 			}
+		}
+	}
+
+	@Override
+	public int updatePlayersToInGame(String roomId) throws Exception {
+
+		String sql = """
+				UPDATE room_player
+				SET status = ?
+				WHERE room_id = ?
+				  AND status = ?
+			""";
+
+		try (Connection conn = DB.getConnection();
+			PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+			pstmt.setString(1, STATUS_IN_GAME);
+			pstmt.setString(2, roomId);
+			pstmt.setString(3, STATUS_IN_ROOM);
+
+			return pstmt.executeUpdate();
 		}
 	}
 

--- a/src/main/java/room/ws/RoomWebSocket.java
+++ b/src/main/java/room/ws/RoomWebSocket.java
@@ -152,6 +152,11 @@ public class RoomWebSocket {
 					break;
 				}
 
+				case "GAME_START": {
+					service.sendIfOpen(session, "GAME_START", Map.of());
+					break;
+				}
+
 				default:
 					service.sendIfOpen(session, "ERROR", Map.of(
 						"code", "UNSUPPORTED_TYPE",

--- a/src/main/java/room/ws/RoomWebSocketService.java
+++ b/src/main/java/room/ws/RoomWebSocketService.java
@@ -96,6 +96,21 @@ public class RoomWebSocketService {
 		}
 	}
 
+	/**
+	 * 게임 시작 브로드캐스트
+	 * - 클라이언트는 GAME_START 수신 시 location.href로 이동
+	 */
+	public void broadcastGameStart(String roomId, String gameId, String playType) {
+		if (roomId == null || roomId.isBlank())
+			return;
+
+		Map<String, Object> payload = new HashMap<>();
+		payload.put("roomId", roomId);
+		payload.put("playType", playType); // "0"(개인전) / "1"(팀전)
+
+		broadcast(roomId, "GAME_START", payload);
+	}
+
 	private void broadcast(String roomId, String type, Map<String, Object> payload) {
 		Set<Session> sessions = roomRegistry.getSessions(roomId);
 		for (Session s : sessions) {

--- a/src/main/webapp/WEB-INF/views/lobby.jsp
+++ b/src/main/webapp/WEB-INF/views/lobby.jsp
@@ -36,6 +36,7 @@
             로그아웃
           </button>
         </form>
+        <button class="btn" onclick="window.location.href='/user/my'">마이페이지</button> 
       </c:otherwise>
     </c:choose>
   </div>

--- a/src/main/webapp/WEB-INF/views/room.jsp
+++ b/src/main/webapp/WEB-INF/views/room.jsp
@@ -13,12 +13,23 @@
 <body>
   <main class="wrap" id="room-page"
         data-room-id="<c:out value='${roomId}'/>"
-        data-room-name="<c:out value='${roomName}'/>">
+        data-room-name="<c:out value='${roomName}'/>"
+        data-play-type="<c:out value='${playType}'/>"
+        data-host-user-id="<c:out value='${hostUserId}'/>"
+        >
 
     <header class="header">
       <div class="title">
         <h2>🎮 방: <c:out value="${roomName}" /></h2>
         <p class="muted">roomId: <c:out value="${roomId}" /></p>
+		<p class="muted">
+		  playType:
+		  <c:choose>
+		    <c:when test="${playType eq '0'}">개인전</c:when>
+		    <c:when test="${playType eq '1'}">팀전</c:when>
+		    <c:otherwise>알 수 없음</c:otherwise>
+		  </c:choose>
+		</p>        
       </div>
 
       <div class="actions">
@@ -36,9 +47,18 @@
     </c:if>
 
     <section class="grid">
-      <section class="card">
-        <h3>👥 참가자</h3>
-        <ul id="user-list" class="user-list"></ul>
+      <section class="card side-nav">
+       	 <div>
+       	  <h3>👥 참가자</h3>
+          <ul id="user-list" class="user-list"></ul>
+       	 </div>
+         <form id="start-form"
+        method="post"
+        action="${pageContext.request.contextPath}/game/start?roomId=${roomId}&playType=${playType}">
+		    <button type="submit" id="btn-start" class="btn-start">
+		      🎯 시작하기
+		    </button>
+		  </form>
       </section>
       <section class="card">
         <h3>💬 채팅</h3>
@@ -54,7 +74,6 @@
       </section>
     </section>
   </main>
-
   <script src="/static/room/room.js"></script>
 </body>
 </html>

--- a/src/main/webapp/static/lobby/lobby.js
+++ b/src/main/webapp/static/lobby/lobby.js
@@ -77,12 +77,13 @@
   }
 
   function toRowHtml(r) {
-    const roomId = r.id ?? r.roomId ?? "";
+    const roomId = r.id ?? "";
     const roomName = r.roomName ?? "-";
     const isPublic = (String(r.isPublic) === "1") ? "공개" : "비공개 🔒";
     const playType = (String(r.playType) === "0") ? "개인전" : "팀전";
     const current = r.currentUserCnt ?? 0;
     const total = r.totalUserCnt ?? 0;
+    
 
     const disabledAttr = IS_LOGIN ? "" : "disabled";
     const titleAttr = IS_LOGIN ? "" : `title="로그인이 필요합니다."`;
@@ -95,7 +96,8 @@
         <td>${current} / ${total}</td>
         <td>
           <form class="enter-room-form" action="${CTX}/room/enter"" method="post">
-            <input type="hidden" name="roomId" value="${escapeHtml(roomId)}" />
+            <input type="hidden" name="playType" value="${escapeHtml(r.playType)}" />	
+			<input type="hidden" name="roomId" value="${escapeHtml(roomId)}" />	
             <button type="submit" ${disabledAttr} ${titleAttr}>입장</button>
           </form>
         </td>

--- a/src/main/webapp/static/room/room.css
+++ b/src/main/webapp/static/room/room.css
@@ -85,3 +85,9 @@ button {
 button:hover {
   background: #f5f5f5;
 }
+
+.side-nav {
+	display:flex;
+	flex-direction: column;
+	justify-content: space-between;
+}

--- a/src/main/webapp/static/room/room.js
+++ b/src/main/webapp/static/room/room.js
@@ -185,6 +185,22 @@
           handleError(msg);
           break;
         }
+        
+        case "GAME_START": {
+		  const { roomId, playType } = msg.payload || {};
+		  
+		  console.log("[WS GAME START]", roomId, playType);
+		  if (!roomId || !playType) return;
+		
+		  if (String(playType) === "0") {
+		    location.href = `/game/single?roomId=${encodeURIComponent(roomId)}`;
+		  } else if (String(playType) === "1") {
+		    location.href = `/game/multi?roomId=${encodeURIComponent(roomId)}`;
+		  } else {	
+		    console.warn("Unknown playType:", playType);
+		  }
+		  break;
+		}
 
         default:
           console.log("[WS] message:", msg);


### PR DESCRIPTION
## 📌 작업 내용

대기방에서 방장이 게임 시작 버튼을 누르면, 게임 참가자 상태를 확정하고 WebSocket 이벤트를 통해 모든 참가자를 게임 화면으로 전환하는 흐름을 구현했습니다.

### 🔄 전체 흐름
1. **방장 게임 시작**
   - `room_player.status`를 `IN_GAME(1)`로 업데이트
   - 실제 게임 참가자 확정

2. **WebSocket 이벤트 전송**
   - 해당 `roomId`의 `status = 1` 참가자에게 `GAME_START` 이벤트 브로드캐스트

3. **클라이언트 처리**
   - `GAME_START` 이벤트 수신 시  
     `/game?roomId=...&playType=...` 로 리다이렉트


## 🔗 관련 이슈

- closes #60 


<br>

## 👀 리뷰 시 참고사항

- 리뷰어가 중점적으로 보면 좋을 부분을 작성해 주세요.
- 고민한 지점이나 피드백 받고 싶은 부분이 있다면 함께 남겨주세요.

<br>

## 💭 느낀 점

- DB를 기반으로 WebSocket 상태 변경 알림 트리거로 사용하여 클라이언트 간 상태 불일치 문제를 효과적으로 해결할 수 있었다.

<br>

## 💻 스크린샷 (선택)

- 필요한 경우 첨부해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 게임 시작 기능 추가 - 플레이 타입(개인전/팀전)에 따라 적절한 게임 페이지로 자동 이동
  * 방 페이지에 게임 시작 버튼 추가
  * 게임 타입 정보 방 페이지에 표시
  * 마이페이지 버튼을 로비에 추가

* **개선 사항**
  * 게임 시작 시 플레이어 상태 자동 업데이트
  * 방 참여 흐름에 플레이 타입 정보 통합
  * 호스트 인증을 통한 게임 시작 검증 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->