### PR TITLE
[FIX] 마이페이지 관련 controller 경로 수정

### DIFF
--- a/src/main/java/friend/controller/FriendController.java
+++ b/src/main/java/friend/controller/FriendController.java
@@ -8,6 +8,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 import com.google.gson.Gson;
 
@@ -86,6 +87,9 @@ public class FriendController extends HttpServlet {
 			case "accept":
 				handleAcceptRequest(req, res, userId);
 				break;
+			case "reject":
+				handleRejectRequest(req, res, userId);
+				break;
 			case "remove":
 				handleRemoveFriend(req, res, userId);
 				break;
@@ -111,6 +115,27 @@ public class FriendController extends HttpServlet {
 	private void handleGetPendingRequests(HttpServletResponse res, String userId) throws IOException {
 		List<FriendDTO> requests = friendService.getPendingRequests(userId);
 		sendSuccess(res, requests);
+	}
+
+	/**
+	 * POST /friend/reject - 친구 요청 거절
+	 */
+	private void handleRejectRequest(HttpServletRequest req, HttpServletResponse res, String userId) throws
+		IOException {
+		FriendAcceptDTO body = gson.fromJson(req.getReader(), FriendAcceptDTO.class);
+
+		if (body == null || body.getRequesterId() == null || body.getRequesterId().isBlank()) {
+			sendError(res, 400, "requesterId가 필요합니다.");
+			return;
+		}
+
+		boolean success = friendService.rejectFriendRequest(body.getRequesterId(), userId);
+
+		if (success) {
+			sendSuccess(res, "친구 요청을 거절했습니다.");
+		} else {
+			sendError(res, 400, "친구 요청 거절에 실패했습니다.");
+		}
 	}
 
 	/**
@@ -198,13 +223,11 @@ public class FriendController extends HttpServlet {
 	 * 세션에서 로그인한 사용자 ID 가져오기
 	 */
 	private String getLoginUserId(HttpServletRequest req) {
-		// HttpSession session = req.getSession(false);
-		// if (session == null) {
-		// 	return null;
-		// }
-		// return (String)session.getAttribute("userId");
-
-		return "user-001";
+		HttpSession session = req.getSession(false);
+		if (session == null) {
+			return null;
+		}
+		return (String)session.getAttribute("loginUserId");
 	}
 
 	/**

--- a/src/main/java/friend/dto/FriendDTO.java
+++ b/src/main/java/friend/dto/FriendDTO.java
@@ -18,4 +18,10 @@ public class FriendDTO {
 	private String friendId; // 친구 요청을 받은 사람
 	private String status; // PENDING, ACCEPTED, BLOCKED
 	private Timestamp createdAt; // 친구 요청 시간
+
+	// 추가: 화면 표시용 필드
+	private String nickname;      // 친구의 닉네임
+	private Integer totalWin;     // 친구의 승수
+	private Integer totalLose;    // 친구의 패수
+	private Double winRate;       // 친구의 승률
 }

--- a/src/main/java/friend/service/FriendService.java
+++ b/src/main/java/friend/service/FriendService.java
@@ -35,4 +35,9 @@ public interface FriendService {
 	 * 친구 차단
 	 */
 	boolean blockFriend(String userId, String friendId);
+
+	/**
+	 * 친구 요청 거절
+	 */
+	boolean rejectFriendRequest(String requesterId, String targetId);
 }

--- a/src/main/java/friend/service/FriendServiceImpl.java
+++ b/src/main/java/friend/service/FriendServiceImpl.java
@@ -1,5 +1,7 @@
 package friend.service;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -7,6 +9,7 @@ import java.util.List;
 import friend.dao.FriendDAO;
 import friend.dao.FriendDAOImpl;
 import friend.dto.FriendDTO;
+import util.DB;
 
 public class FriendServiceImpl implements FriendService {
 
@@ -34,6 +37,26 @@ public class FriendServiceImpl implements FriendService {
 			int result = friendDAO.createRequest(requesterId, receiverId);
 			return result > 0;
 		} catch (SQLException e) {
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	@Override
+	public boolean rejectFriendRequest(String requesterId, String targetId) {
+		// friend_request가 아니라 friend 테이블입니다!
+		String sql = "DELETE FROM friend WHERE user_id = ? AND friend_id = ? AND status = 'PENDING'";
+
+		try (Connection conn = DB.getConnection();
+			 PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+			pstmt.setString(1, requesterId);
+			pstmt.setString(2, targetId);
+
+			int result = pstmt.executeUpdate();
+			return result > 0;
+
+		} catch (Exception e) {
 			e.printStackTrace();
 			return false;
 		}

--- a/src/main/java/user/controller/MyPageController.java
+++ b/src/main/java/user/controller/MyPageController.java
@@ -110,9 +110,9 @@ public class MyPageController extends HttpServlet {
 						.gameId(rs.getString("game_id"))
 						.roomId(rs.getString("room_id"))
 						.userId(rs.getString("user_id"))
-						.stoneColor(rs.getString("stone_color"))
-						.gameResult(rs.getString("game_result"))
-						.playType(rs.getString("play_type"))
+						.stoneColor(String.valueOf(rs.getInt("stone_color")))
+						.gameResult(String.valueOf(rs.getInt("game_result")))
+						.playType(String.valueOf(rs.getInt("play_type")))
 						.finishedAt(rs.getTimestamp("finished_at"))
 						.build();
 					list.add(dto);

--- a/src/main/webapp/WEB-INF/views/record/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/record/mypage.jsp
@@ -18,7 +18,7 @@
         /* 레이아웃: 좌우 2단 분리 */
         .mypage-wrapper {
             display: grid;
-            grid-template-columns: 2fr 1fr; /* 왼쪽 2 : 오른쪽 1 비율 */
+            grid-template-columns: 2fr 1fr;
             gap: 20px;
             max-width: 1200px;
             margin: 40px auto;
@@ -34,7 +34,6 @@
             margin-bottom: 20px;
         }
 
-        /* 왼쪽 영역 (프로필, 전적) 스타일은 기존 유지 */
         .profile-header {
             display: flex;
             align-items: center;
@@ -96,13 +95,28 @@
             background: #f1f3f5;
         }
 
-        /* --- 오른쪽 영역 (친구) 스타일 --- */
+        /* 오른쪽 영역 스타일 */
         .section-title {
             font-size: 18px;
             font-weight: bold;
             margin-bottom: 15px;
             border-bottom: 2px solid #eee;
             padding-bottom: 10px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        /* 알림 배지 */
+        .badge {
+            background: #ff4757;
+            color: white;
+            border-radius: 10px;
+            padding: 2px 8px;
+            font-size: 12px;
+            font-weight: bold;
+            min-width: 20px;
+            text-align: center;
         }
 
         /* 검색창 */
@@ -157,6 +171,10 @@
             font-size: 12px;
         }
 
+        .btn-request:hover {
+            background: #45a049;
+        }
+
         /* 친구 목록 */
         .friend-list {
             list-style: none;
@@ -187,6 +205,7 @@
             align-items: center;
             justify-content: center;
             font-size: 14px;
+            flex-shrink: 0;
         }
 
         .f-info {
@@ -203,6 +222,41 @@
             color: #888;
         }
 
+        /* 친구 요청 버튼 */
+        .pending-actions {
+            display: flex;
+            gap: 5px;
+            flex-shrink: 0;
+        }
+
+        .btn-accept {
+            background: #4CAF50;
+            color: white;
+            border: none;
+            padding: 5px 10px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 12px;
+        }
+
+        .btn-accept:hover {
+            background: #45a049;
+        }
+
+        .btn-reject {
+            background: #f44336;
+            color: white;
+            border: none;
+            padding: 5px 10px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 12px;
+        }
+
+        .btn-reject:hover {
+            background: #da190b;
+        }
+
         .btn-back {
             display: block;
             width: 100%;
@@ -214,12 +268,23 @@
             border-radius: 6px;
             margin-top: 20px;
         }
+
+        .btn-back:hover {
+            background: #333;
+        }
+
+        /* 빈 상태 메시지 */
+        .empty-message {
+            padding: 10px;
+            color: #888;
+            text-align: center;
+        }
     </style>
 </head>
 <body>
 
 <div class="mypage-wrapper">
-
+    <!-- 왼쪽 영역 -->
     <div class="left-col">
         <div class="card">
             <div class="profile-header">
@@ -294,7 +359,9 @@
         <a href="${pageContext.request.contextPath}/lobby" class="btn-back">← 로비로 돌아가기</a>
     </div>
 
+    <!-- 오른쪽 영역 -->
     <div class="right-col">
+        <!-- 친구 찾기 -->
         <div class="card">
             <div class="section-title">🔍 친구 찾기</div>
             <div class="search-box">
@@ -316,12 +383,24 @@
             </div>
         </div>
 
+        <!-- 받은 친구 요청 -->
+        <div class="card">
+            <div class="section-title">
+                📬 받은 친구 요청
+                <span class="badge" id="pendingCount" style="display:none;">0</span>
+            </div>
+            <ul class="friend-list" id="pendingList">
+                <li class="empty-message">대기 중인 요청이 없습니다.</li>
+            </ul>
+        </div>
+
+        <!-- 내 친구 목록 -->
         <div class="card">
             <div class="section-title">👥 내 친구 (${myFriends.size()})</div>
             <ul class="friend-list">
                 <c:choose>
                     <c:when test="${empty myFriends}">
-                        <li style="padding:10px; color:#888; text-align:center;">등록된 친구가 없습니다.</li>
+                        <li class="empty-message">등록된 친구가 없습니다.</li>
                     </c:when>
                     <c:otherwise>
                         <c:forEach var="friend" items="${myFriends}">
@@ -330,7 +409,7 @@
                                 <div class="f-info">
                                     <div class="f-name">${friend.nickname}</div>
                                     <div class="f-status">
-                                        승률: ${friend.winRate}% (ID: ${friend.friendId})
+                                        승률: ${friend.winRate}% (${friend.totalWin}승 ${friend.totalLose}패)
                                     </div>
                                 </div>
                             </li>
@@ -345,7 +424,155 @@
 <script>
     const CTX = "${pageContext.request.contextPath}";
 
-    // 1. 유저 검색 (UserController 호출)
+    // 페이지 로드 시 대기 중인 친구 요청 불러오기
+    window.addEventListener('DOMContentLoaded', function () {
+        loadPendingRequests();
+    });
+
+    // 1. 대기 중인 친구 요청 조회
+    function loadPendingRequests() {
+        fetch(CTX + '/friend/pending')
+            .then(res => res.json())
+            .then(json => {
+                if (json.success) {
+                    const requests = json.data;
+                    updatePendingUI(requests);
+                } else {
+                    console.error("친구 요청 조회 실패:", json.message);
+                }
+            })
+            .catch(err => {
+                console.error("친구 요청 조회 중 오류:", err);
+            });
+    }
+
+    // 2. 대기 중인 요청 UI 업데이트
+    function updatePendingUI(requests) {
+        const pendingList = document.getElementById("pendingList");
+        const pendingCount = document.getElementById("pendingCount");
+
+        if (requests.length === 0) {
+            pendingList.innerHTML = '<li class="empty-message">대기 중인 요청이 없습니다.</li>';
+            pendingCount.style.display = "none";
+            return;
+        }
+
+        // 배지 표시
+        pendingCount.textContent = requests.length;
+        pendingCount.style.display = "inline-block";
+
+        // 요청 목록 렌더링
+        pendingList.innerHTML = '';
+
+        requests.forEach(req => {
+            console.log("친구 요청 데이터:", req); // 디버깅용
+
+            const li = document.createElement('li');
+            li.className = 'friend-item';
+
+            // DOM 요소 직접 생성
+            const avatar = document.createElement('div');
+            avatar.className = 'f-avatar';
+            avatar.textContent = req.nickname.charAt(0);
+
+            const info = document.createElement('div');
+            info.className = 'f-info';
+
+            const name = document.createElement('div');
+            name.className = 'f-name';
+            name.textContent = req.nickname;
+
+            const status = document.createElement('div');
+            status.className = 'f-status';
+            status.textContent = `승률: ${req.winRate}% (${req.totalWin}승 ${req.totalLose}패)`;
+
+            info.appendChild(name);
+            info.appendChild(status);
+
+            const actions = document.createElement('div');
+            actions.className = 'pending-actions';
+
+            const acceptBtn = document.createElement('button');
+            acceptBtn.className = 'btn-accept';
+            acceptBtn.textContent = '수락';
+            acceptBtn.onclick = function () {
+                // ✅ req.friendId가 아니라 req.userId 사용!
+                acceptRequest(req.userId, req.nickname);
+            };
+
+            const rejectBtn = document.createElement('button');
+            rejectBtn.className = 'btn-reject';
+            rejectBtn.textContent = '거절';
+            rejectBtn.onclick = function () {
+                // ✅ req.friendId가 아니라 req.userId 사용!
+                rejectRequest(req.userId, req.nickname);
+            };
+
+            actions.appendChild(acceptBtn);
+            actions.appendChild(rejectBtn);
+
+            li.appendChild(avatar);
+            li.appendChild(info);
+            li.appendChild(actions);
+
+            pendingList.appendChild(li);
+        });
+    }
+
+
+    // 3. 친구 요청 수락
+    function acceptRequest(requesterId, nickname) {
+        if (!confirm(nickname + "님의 친구 요청을 수락하시겠습니까?")) {
+            return;
+        }
+
+        fetch(CTX + '/friend/accept', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({requesterId: requesterId})
+        })
+            .then(res => res.json())
+            .then(json => {
+                if (json.success) {
+                    alert("친구 요청을 수락했습니다!");
+                    location.reload();  // 페이지 새로고침하여 친구 목록 업데이트
+                } else {
+                    alert(json.message || "친구 요청 수락 실패");
+                }
+            })
+            .catch(err => {
+                console.error(err);
+                alert("서버 오류 발생");
+            });
+    }
+
+    // 4. 친구 요청 거절
+    function rejectRequest(requesterId, nickname) {
+        if (!confirm(nickname + "님의 친구 요청을 거절하시겠습니까?")) {
+            return;
+        }
+
+        fetch(CTX + '/friend/reject', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({requesterId: requesterId})
+        })
+            .then(res => res.json())
+            .then(json => {
+                if (json.success) {
+                    alert("친구 요청을 거절했습니다.");
+                    loadPendingRequests();  // 요청 목록만 새로고침
+                } else {
+                    alert(json.message || "친구 요청 거절 실패");
+                }
+            })
+            .catch(err => {
+                console.error(err);
+                alert("서버 오류 발생");
+            });
+    }
+
+    // 5. 유저 검색
     function searchUser() {
         const nickname = document.getElementById("searchNickname").value.trim();
         if (!nickname) {
@@ -353,17 +580,14 @@
             return;
         }
 
-        // GET /user/search?nickname=...
         fetch(CTX + '/user/search?nickname=' + encodeURIComponent(nickname))
             .then(res => res.json())
             .then(json => {
                 if (json.success) {
                     const user = json.data;
-                    // 검색 결과 UI 업데이트
                     document.getElementById("foundName").textContent = user.nickname;
                     document.getElementById("foundStats").textContent = user.totalWin + "승 " + user.totalLose + "패";
-                    document.getElementById("foundUserId").value = user.userId; // 숨겨진 ID 저장
-
+                    document.getElementById("foundUserId").value = user.userId;
                     document.getElementById("searchResult").style.display = "block";
                 } else {
                     alert(json.message || "사용자를 찾을 수 없습니다.");
@@ -376,7 +600,7 @@
             });
     }
 
-    // 2. 친구 요청 보내기 (FriendController 호출)
+    // 6. 친구 요청 보내기
     function sendFriendRequest() {
         const targetId = document.getElementById("foundUserId").value;
         if (!targetId) return;
@@ -385,7 +609,6 @@
             return;
         }
 
-        // POST /friend/request
         fetch(CTX + '/friend/request', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
## 📌 작업 내용

친구 요청 수락 시 양쪽 유저의 친구 상태가 일관되게 반영되도록 서비스 로직 수정

이미 친구이거나 대기 중인 요청에 대해 중복 수락이 되지 않도록 방어 로직 추가

마이페이지에서 친구 수/승패 전적 등 사용자 정보가 최신 상태로 보이도록 조회 로직 및 뷰 수정

예외 상황(존재하지 않는 요청, 권한 없는 요청)에 대한 처리 및 응답 메시지 보완
​



<br>

## 🔗 관련 이슈

- closes #67 

<br>

## 👀 리뷰 시 참고사항

- 리뷰어가 중점적으로 보면 좋을 부분을 작성해 주세요.
- 고민한 지점이나 피드백 받고 싶은 부분이 있다면 함께 남겨주세요.

<br>

## 💭 느낀 점

친구 요청 수락처럼 상태가 여러 개 얽혀 있는 로직은 케이스를 놓치기 쉬워서, 테스트 케이스를 더 잘 쪼개야겠다고 느꼈습니다.

마이페이지와 같이 여러 도메인 데이터가 한 번에 모이는 화면은 초기 설계 단계에서부터 응답 DTO와 쿼리 구조를 잘 잡아두는 게 중요하다는 걸 다시 느꼈습니다.
​

<br>

## 💻 스크린샷 (선택)

<img width="350" height="564" alt="image" src="https://github.com/user-attachments/assets/0c51ae58-7a06-47fb-a5cb-95a45719a192" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 친구 요청 거절 기능 추가
* 받은 친구 요청 목록 표시 및 수락/거절 기능 제공
* 친구 목록에서 선수 승률 및 전적 통계 표시

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->