### PR TITLE
[FEAT] 개인전 게임 중 이모티콘 채팅 UI 추가

### DIFF
--- a/src/main/java/game/single/controller/SingleGameController.java
+++ b/src/main/java/game/single/controller/SingleGameController.java
@@ -11,7 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Servlet implementation class SingleGameServlet
  */
-@WebServlet("/single")
+@WebServlet("/game/single")
 public class SingleGameController extends HttpServlet {
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/game/single/ws/SingleWebSocket.java
+++ b/src/main/java/game/single/ws/SingleWebSocket.java
@@ -1,5 +1,9 @@
 package game.single.ws;
 
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
 import javax.websocket.OnClose;
 import javax.websocket.OnMessage;
 import javax.websocket.OnOpen;
@@ -12,19 +16,59 @@ import game.single.service.SingleGameServiceImpl;
 public class SingleWebSocket {
 
 	private static SingleGameServiceImpl service = SingleGameServiceImpl.getInstance();
+	// 이모티콘 채팅 브로드캐스트용 세션 목록
+	private static final Set<Session> sessions = new CopyOnWriteArraySet<>();
 
 	@OnOpen
 	public void onOpen(Session session) throws Exception {
+		sessions.add(session);
 		service.onOpen(session);
 	}
 
 	@OnMessage
 	public void onMessage(String msg, Session session) throws Exception {
-		service.onMessage(msg, session);
+		/* 이모티콘 채팅 메시지면 게임로직으로 안 넘기고 브로드캐스트 */
+		/* 예시: EMOJI_CHAT:😀   또는  EMOJI_CHAT:heart */
+		if (msg != null && msg.startsWith("EMOJI_CHAT:")) {
+			String emoji = msg.substring("EMOJI_CHAT:".length()); // ":" 뒤
+			emoji = emoji == null ? "" : emoji.trim();
+
+			if (!emoji.isEmpty()) {
+				broadcast("{\"type\":\"EMOJI_CHAT\",\"payload\":{\"emoji\":\"" + escapeJson(emoji) + "\"}}");
+			}
+			return;
+		}
+		service.onMessage(msg, session); // 나머지는 기존 게임 로직으로
 	}
 
 	@OnClose
 	public void onClose(Session session) {
+		sessions.remove(session);
 		service.onClose(session);
+	}
+
+	private void broadcast(String json) {
+		for (Session s : sessions) {
+			if (s == null || !s.isOpen())
+				continue;
+			try {
+				s.getBasicRemote().sendText(json);
+			} catch (IOException e) {
+				// 보내기 실패하면 세션 제거
+				try {
+					s.close();
+				} catch (Exception ignore) {}
+				sessions.remove(s);
+			}
+		}
+	}
+
+	/* JSON 문자열 처리 (따옴표/역슬래시/개행) */
+	private static String escapeJson(String s) {
+		return s
+			.replace("\\", "\\\\")
+			.replace("\"", "\\\"")
+			.replace("\n", "\\n")
+			.replace("\r", "\\r");
 	}
 }

--- a/src/main/webapp/chat/gameChat.jsp
+++ b/src/main/webapp/chat/gameChat.jsp
@@ -1,0 +1,37 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<!-- 게임 화면 안에 "채팅(이모티콘)" UI만 추가하는 용도 -->
+<div class="game-chat">
+  <div class="game-chat__header">
+    <span>😀 이모티콘</span>
+    <span id="game-ws-status" class="muted">WS: 준비</span>
+  </div>
+
+  <div id="game-chat-log" class="game-chat__log"></div>
+
+  <div class="game-chat__emoji">
+    <!-- 필요하면 더 추가해도 됨 (value가 서버로 전송됨) -->
+    <button type="button" class="emoji-btn" data-emoji="😀">😀</button>
+    <button type="button" class="emoji-btn" data-emoji="😂">😂</button>
+    <button type="button" class="emoji-btn" data-emoji="😡">😡</button>
+    <button type="button" class="emoji-btn" data-emoji="👍">👍</button>
+    <button type="button" class="emoji-btn" data-emoji="👎">👎</button>
+    <button type="button" class="emoji-btn" data-emoji="❤️">❤️</button>
+  </div>
+</div>
+
+<!-- game.js는 "이모티콘 채팅 전용" 스크립트로 쓸 예정 -->
+<script src="${pageContext.request.contextPath}/static/game/game.js"></script>
+
+<style>
+  /* 최소 스타일(원하면 css 파일로 옮겨도 됨) */
+  .game-chat { border:1px solid #e5e7eb; border-radius:12px; padding:12px; background:#fff; }
+  .game-chat__header { display:flex; justify-content:space-between; align-items:center; margin-bottom:8px; }
+  .game-chat__log { height:140px; overflow:auto; border:1px solid #eee; border-radius:10px; padding:10px; background:#fafafa; }
+  .game-chat__emoji { display:flex; flex-wrap:wrap; gap:8px; margin-top:10px; }
+  .emoji-btn { padding:8px 10px; border:1px solid #ddd; border-radius:10px; background:#fff; cursor:pointer; }
+  .emoji-btn:hover { background:#f5f5f5; }
+  .muted { color:#6b7280; font-size:12px; }
+  .chat-row { margin-bottom:6px; }
+</style>

--- a/src/main/webapp/static/chat/gameChat.js
+++ b/src/main/webapp/static/chat/gameChat.js
@@ -1,0 +1,123 @@
+(() => {
+  const statusEl = document.querySelector("#ws-status");
+  const p1Bubble = document.querySelector("#p1 .bubble");
+  const p2Bubble = document.querySelector("#p2 .bubble");
+
+  /* 서버에서 SINGLE_START로 내려주는 내 돌 색(1 or 2) */
+  let myColor = null;
+
+  /* 상대와 구분용 식별자 -> 새로고침해도 유지 */
+  const CLIENT_ID_KEY = "omok_client_id";
+  let clientId = localStorage.getItem(CLIENT_ID_KEY);
+  if (!clientId) {
+    clientId = crypto?.randomUUID ? crypto.randomUUID() : String(Date.now()) + "_" + Math.random();
+    localStorage.setItem(CLIENT_ID_KEY, clientId);
+  }
+
+  const EMOJI_MAP = {
+    smile: "🙂",
+    angry: "😡",
+    clap: "👏",
+  };
+
+  let ws = null;
+
+  function setStatus(t) {
+    if (statusEl) statusEl.textContent = t;
+  }
+
+  function wsUrl() {
+    const protocol = location.protocol === "https:" ? "wss://" : "ws://";
+    const ctx = window.contextPath || "";
+    /* @ServerEndpoint("/omok") 는 "컨텍스트 경로 + /omok" */
+    return protocol + location.host + ctx + "/omok";
+  }
+
+  function safeJson(raw) {
+    try { return JSON.parse(raw); } catch { return null; }
+  }
+
+  function showBubble(color, emojiChar) {
+    const bubble = (String(color) === "1") ? p1Bubble : p2Bubble;
+    if (!bubble) return;
+
+    bubble.textContent = emojiChar;
+    bubble.style.display = "inline-block";
+
+    /* 1.5초 후 자동 숨김 */
+    window.clearTimeout(bubble._t);
+    bubble._t = window.setTimeout(() => {
+      bubble.style.display = "none";
+      bubble.textContent = "";
+    }, 1500);
+  }
+
+  /* 전역 함수 */
+  window.sendEmoji = (emojiKey) => {
+    const emojiChar = EMOJI_MAP[emojiKey] || emojiKey;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+    /* 내 화면에는 즉시 띄우고 서버에도 전송 */
+    if (myColor) showBubble(myColor, emojiChar);
+
+    /* 서버는 문자열만 받고 다시 브로드캐스트 하니까
+    clientId|emojiKey 로 보내서 수신 시 누가 보냈는지 구분 */
+    const payload = `${clientId}|${emojiKey}`;
+    ws.send(`EMOJI_CHAT:${payload}`);
+  };
+
+  function connect() {
+    setStatus("WS: 연결 중...");
+    ws = new WebSocket(wsUrl());
+
+    ws.onopen = () => {
+      setStatus("WS: 연결됨");
+    };
+
+    ws.onmessage = (e) => {
+      const msg = safeJson(e.data);
+      if (!msg || !msg.type) return;
+
+      /* 게임 시작 시 내 색 받기 */
+      if (msg.type === "SINGLE_START") {
+        myColor = Number(msg.color) || null; // 1 or 2
+        return;
+      }
+
+      /* 이모티콘 채팅 수신 */
+      if (msg.type === "EMOJI_CHAT") {
+        const raw = msg.payload?.emoji ?? "";
+        const [fromId, emojiKey] = String(raw).split("|", 2);
+
+        const emojiChar = EMOJI_MAP[emojiKey] || emojiKey || "🙂";
+
+        /* 내 clientId면 내 말풍선, 아니면 상대 말풍선 */
+        if (fromId && fromId === clientId) {
+          if (myColor) showBubble(myColor, emojiChar);
+          else { showBubble(1, emojiChar); showBubble(2, emojiChar); }
+        } else {
+          if (myColor) {
+            const other = (myColor === 1) ? 2 : 1;
+            showBubble(other, emojiChar);
+          } else {
+            /* 색 모르면 일단 둘 다 보여주기 */
+            showBubble(1, emojiChar);
+            showBubble(2, emojiChar);
+          }
+        }
+        return;
+      }
+
+      /* 나머지 게임 메시지는 기존 게임 로직 파일이 따로 있으면 거기서 처리 여긴 채팅 UI만 붙이는 파일 */
+    };
+
+    ws.onclose = () => setStatus("WS: 종료됨");
+    ws.onerror = () => setStatus("WS: 에러");
+  }
+
+  window.addEventListener("beforeunload", () => {
+    try { ws?.close(); } catch (_) {}
+  });
+
+  connect();
+})();


### PR DESCRIPTION
## 📌 작업 내용

- 개인전 게임 화면에서 텍스트 채팅 대신 이모티콘 채팅 UI를 사용할 수 있도록 추가
- WebSocket을 통해 EMOJI_CHAT 메시지를 송수신하고 말풍선 형태로 화면에 표시
- UI 및 클라이언트 단 처리 중심으로 작업 -> 게임 로직 영향X

<br>

## 🔗 관련 이슈

- closes #75 

<br>

## 👀 리뷰 시 참고사항

- 현재는 채팅 UI 연동 단계로 게임 로직/턴 처리/승패 판정과는 분리되어 있음
- 실제 게임 중 사용 여부 및 UX 세부 조정은 이후 단계에서 보완 예정
- WebSocket 메시지 타입: EMOJI_CHAT

<br>

## 💭 느낀 점

- 추후 팀전에서도 재사용 가능하도록 확장해봐야겠음

<br>

## 💻 스크린샷 (선택)

- 필요한 경우 첨부해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 게임 중 실시간 이모지 채팅 기능이 추가되었습니다. 플레이어는 이모지 팔레트에서 원하는 이모지를 선택하여 상대방과 빠르게 의사소통할 수 있습니다. 각 이모지는 해당 플레이어의 색상으로 표시되어 누가 보냈는지 쉽게 구분됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->