### PR TITLE
[FEAT] Room WebSocket 기반 방 입장 및 게임 전환 로직 개선

### DIFF
--- a/src/main/java/lobby/ws/LobbyWebSocket.java
+++ b/src/main/java/lobby/ws/LobbyWebSocket.java
@@ -155,6 +155,16 @@ public class LobbyWebSocket {
 		}
 	}
 
+	public void sendHostAutoEnter(Session s, String roomId, String roomName, int playType, String hostUserId) {
+		Map<String, Object> payload = new HashMap<>();
+		payload.put("roomId", roomId);
+		payload.put("roomName", roomName);
+		payload.put("playType", playType);
+		payload.put("hostUserId", hostUserId);
+
+		sendRawIfOpen(s, "ROOM_AUTO_ENTER", payload);
+	}
+
 	/**
 	 * LobbyWebSocketService를 거치지 않고도 간단 payload 전송이 필요할 때 사용.
 	 * (CONNECTED 같은 초기 메시지 용)

--- a/src/main/java/session/RoomTransitionRegistry.java
+++ b/src/main/java/session/RoomTransitionRegistry.java
@@ -1,0 +1,36 @@
+package session;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class RoomTransitionRegistry {
+	private static final RoomTransitionRegistry inst = new RoomTransitionRegistry();
+
+	public static RoomTransitionRegistry getInstance() {
+		return inst;
+	}
+
+	private final ConcurrentHashMap<String, Long> moving = new ConcurrentHashMap<>();
+
+	private String key(String roomId, String userId) {
+		return roomId + ":" + userId;
+	}
+
+	public void markMoving(String roomId, String userId, long ttlMs) {
+		moving.put(key(roomId, userId), System.currentTimeMillis() + ttlMs);
+	}
+
+	public boolean isMoving(String roomId, String userId) {
+		Long exp = moving.get(key(roomId, userId));
+		if (exp == null)
+			return false;
+		if (System.currentTimeMillis() > exp) {
+			moving.remove(key(roomId, userId));
+			return false;
+		}
+		return true;
+	}
+
+	public void clear(String roomId, String userId) {
+		moving.remove(key(roomId, userId));
+	}
+}


### PR DESCRIPTION
## 📌 작업 내용

- 방장 방 생성 시 자동으로 해당 방에 입장되도록 로직 구현
- Room WebSocket 종료(`@OnClose`) 시 퇴장 상황을 분기하여 처리
  - 정상 퇴장 / 페이지 이동 / 예외 종료에 따른 처리 분리

<br>

## 🔗 관련 이슈

- closes #81

<br>

## 👀 리뷰 시 참고사항


<br>

## 💭 느낀 점
- WebSocket Session 연결 종료에서 브라우저 종료, 새로고침, 네트워크 끊김 상황까지 다양하게 고려해볼 수 있어서 좋았습니다.

<br>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특수 문자를 포함한 방 이름 처리 개선
  * 방 호스트 자동 입장 알림 기능 추가

* **버그 수정**
  * 방 간 전환 시 세션 관리 안정성 개선
  * 방 종료 시 정리 프로세스 강화

* **개선사항**
  * 방 생성 및 입장 흐름 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->