### PR TITLE
[FEAT] 단체전 이모티콘 채팅 UI 및 구조 분리

### DIFF
--- a/src/main/java/game/multi/ws/MultiWebSocket.java
+++ b/src/main/java/game/multi/ws/MultiWebSocket.java
@@ -1,6 +1,8 @@
 package game.multi.ws;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.http.HttpSession;
 import javax.websocket.EndpointConfig;
@@ -10,6 +12,9 @@ import javax.websocket.OnMessage;
 import javax.websocket.OnOpen;
 import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 import config.WebSocketConfig;
 import game.multi.dao.MultiPlayerDAO;
@@ -21,58 +26,147 @@ import game.multi.service.MultiGameService.SendJob;
 public class MultiWebSocket {
 
 	private static final MultiGameService service = new MultiGameService();
-	
+
 	private static final MultiPlayerDAO multiPlayerDao = new MultiPlayerDAOImpl();
 
+	/* 
+	 * room 단위 세션/유저/닉/슬롯 캐시
+	 * - 이모지 브로드캐스트를 해당 room에만 하기 위함
+	 * - GAME_MULTI_START 메시지를 dispatch에서 감지해 slot을 캐싱함
+	 */
+	private static final Map<String, String> sessionRoomMap = new ConcurrentHashMap<>(); // sessionId -> roomId
+	private static final Map<String, String> sessionUserMap = new ConcurrentHashMap<>(); // sessionId -> userId
+	private static final Map<String, String> sessionNickMap = new ConcurrentHashMap<>(); // sessionId -> nickname
+	private static final Map<String, Integer> sessionSlotMap = new ConcurrentHashMap<>(); // sessionId -> slot(0~3)
+
+	private static final Map<String, Map<String, Session>> roomSessions = new ConcurrentHashMap<>(); // roomId -> (sessionId -> Session)
+
+	private static final Gson gson = new Gson();
+
 	@OnOpen
-    public void onOpen(Session session, EndpointConfig config) {
-        try {
-        	// HttpSession에서 userId 가져오기
-        	HttpSession httpSession = (HttpSession) config.getUserProperties().get(HttpSession.class.getName());
-        	String userId = null;
-        	if (httpSession != null) {
-        		userId = (String) httpSession.getAttribute("loginUserId");
-        	}
-        	
-            // URL 쿼리 스트링에서 roomId 파싱
-            String query = session.getRequestURI().getQuery();
-            String roomId = getParameterValue(query, "roomId");
+	public void onOpen(Session session, EndpointConfig config) {
+		try {
+			// HttpSession에서 userId 가져오기
+			HttpSession httpSession = (HttpSession)config.getUserProperties().get(HttpSession.class.getName());
+			String userId = null;
+			if (httpSession != null) {
+				userId = (String)httpSession.getAttribute("loginUserId");
+			}
 
-            if (roomId == null || roomId.trim().isEmpty()) {
-                // 방 ID가 없으면 에러 처리 혹은 기본방("default")
-                roomId = "default"; 
-            }
-            
-            // DB로 방 멤버 검증
-            if (!multiPlayerDao.isMember(roomId, userId)) {
-            	session.close();
-            	return;
-            }
+			// URL 쿼리 스트링에서 roomId 파싱
+			String query = session.getRequestURI().getQuery();
+			String roomId = getParameterValue(query, "roomId");
 
-            // Service에 roomId와 userId 함께 전달
-            List<SendJob> jobs = service.handleOpen(session, roomId, userId);
-            dispatch(session, jobs);
-            
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-	
+			if (roomId == null || roomId.trim().isEmpty()) {
+				roomId = "default"; // 방 ID가 없을 때
+			}
+
+			// DB로 방 멤버 검증
+			if (!multiPlayerDao.isMember(roomId, userId)) {
+				session.close();
+				return;
+			}
+
+			/* 
+			 * room/session 캐시 등록
+			 * SingleWebSocket과 동일 -> loginNickname 사용
+			 */
+			sessionRoomMap.put(session.getId(), roomId);
+			if (userId != null)
+				sessionUserMap.put(session.getId(), userId);
+
+			String nickname = null;
+			if (httpSession != null) {
+				nickname = (String)httpSession.getAttribute("loginNickname");
+			}
+			if (nickname == null || nickname.isBlank()) {
+				nickname = (userId != null ? userId : "unknown");
+			}
+			sessionNickMap.put(session.getId(), nickname);
+
+			roomSessions.computeIfAbsent(roomId, k -> new ConcurrentHashMap<>())
+				.put(session.getId(), session);
+
+			// Service에 roomId와 userId 함께 전달
+			List<SendJob> jobs = service.handleOpen(session, roomId, userId);
+			dispatch(session, jobs);
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
 	// 쿼리 스트링 파싱 헬퍼 메서드
-    private String getParameterValue(String query, String name) {
-        if (query == null) return null;
-        for (String param : query.split("&")) {
-            String[] pair = param.split("=");
-            if (pair.length > 1 && pair[0].equals(name)) {
-                return pair[1];
-            }
-        }
-        return null;
-    }
+	private String getParameterValue(String query, String name) {
+		if (query == null)
+			return null;
+		for (String param : query.split("&")) {
+			String[] pair = param.split("=");
+			if (pair.length > 1 && pair[0].equals(name)) {
+				return pair[1];
+			}
+		}
+		return null;
+	}
 
 	@OnMessage
 	public void onMessage(String msg, Session session) {
 		try {
+			/* 
+			 * 이모지 채팅: "EMOJI_CHAT:smile" 텍스트 프로토콜
+			 * - 같은 방에 브로드캐스트
+			 * - SingleWebSocket과 동일한 JSON 포맷(type/payload) + slot 추가
+			 */
+			if (msg != null && msg.startsWith("EMOJI_CHAT:")) {
+				String emojiKey = msg.substring("EMOJI_CHAT:".length()).trim();
+				if (emojiKey.isEmpty())
+					return;
+
+				String roomId = sessionRoomMap.get(session.getId());
+				if (roomId == null)
+					return;
+
+				String userId = sessionUserMap.get(session.getId());
+				String nickname = sessionNickMap.get(session.getId());
+				if (nickname == null || nickname.isBlank())
+					nickname = (userId != null ? userId : "unknown");
+
+				int slot = -1;
+				Integer cachedSlot = sessionSlotMap.get(session.getId());
+				if (cachedSlot != null)
+					slot = cachedSlot;
+
+				JsonObject root = new JsonObject();
+				root.addProperty("type", "EMOJI_CHAT");
+
+				JsonObject payload = new JsonObject();
+				if (userId != null)
+					payload.addProperty("from", userId);
+				payload.addProperty("fromNick", nickname);
+				payload.addProperty("emoji", emojiKey);
+				if (slot >= 0)
+					payload.addProperty("slot", slot);
+
+				root.add("payload", payload);
+
+				String json = gson.toJson(root);
+
+				// room 내 세션에게만 전송
+				Map<String, Session> targets = roomSessions.get(roomId);
+				if (targets != null) {
+					for (Session s : targets.values()) {
+						if (s != null && s.isOpen()) {
+							try {
+								synchronized (s) {
+									s.getBasicRemote().sendText(json);
+								}
+							} catch (Exception ignore) {}
+						}
+					}
+				}
+				return;
+			}
+
 			List<SendJob> jobs = service.handleMessage(session, msg);
 			dispatch(session, jobs);
 		} catch (Exception e) {
@@ -83,6 +177,22 @@ public class MultiWebSocket {
 	@OnClose
 	public void onClose(Session session) {
 		try {
+			/* room/session 캐시 정리 */
+			String roomId = sessionRoomMap.remove(session.getId());
+			sessionUserMap.remove(session.getId());
+			sessionNickMap.remove(session.getId());
+			sessionSlotMap.remove(session.getId());
+
+			if (roomId != null) {
+				Map<String, Session> targets = roomSessions.get(roomId);
+				if (targets != null) {
+					targets.remove(session.getId());
+					if (targets.isEmpty()) {
+						roomSessions.remove(roomId);
+					}
+				}
+			}
+
 			List<SendJob> jobs = service.handleClose(session);
 			dispatch(session, jobs);
 		} catch (Exception e) {
@@ -97,24 +207,33 @@ public class MultiWebSocket {
 
 	private void dispatch(Session fallback, List<SendJob> jobs) {
 		// 전체에게 보내야 할 경우를 대비해 현재 열려있는 모든 세션을 가져옴
-		// Service가 target=null을 주면 "모두에게" 보냄
+		// Service가 target=null을 주면 모두에게 보냄
 
 		for (SendJob job : jobs) {
 			try {
+				/*
+				 * GAME_MULTI_START를 감지해서 slot 캐싱
+				 * GameRoom이 보내는 {"type":"GAME_MULTI_START","slot":i,...}를 여기서 읽어둠
+				 */
+				if (job.target() != null) {
+					cacheSlotIfStart(job.target(), job.text());
+				}
+				// ==================================================
+
 				// 1. 전체 전송 (Broadcast)
 				if (job.target() == null) {
 					// 타겟이 없으면(null) => 브로드캐스트 (전체 전송)
 					for (Session s : fallback.getOpenSessions()) {
 						if (s.isOpen()) {
 							try {
-								// 동기화 처리로 충돌 방지
+								// 충돌 방지용 동기화 처리
 								synchronized (s) {
 									s.getBasicRemote().sendText(job.text());
 								}
-							} catch (Exception e) { }
+							} catch (Exception e) {}
 						}
 					}
-				} 
+				}
 				// 2. 개별 전송 (Unicast)
 				else {
 					if (job.target().isOpen()) {
@@ -122,10 +241,34 @@ public class MultiWebSocket {
 							synchronized (job.target()) {
 								job.target().getBasicRemote().sendText(job.text());
 							}
-						} catch (Exception e) { }
+						} catch (Exception e) {}
 					}
 				}
-			} catch (Exception ignore) { }
+			} catch (Exception ignore) {}
 		}
+	}
+
+	/* GAME_MULTI_START 메시지에서 slot을 캐싱 */
+	private void cacheSlotIfStart(Session target, String text) {
+		try {
+			if (text == null)
+				return;
+			// 파싱 최소화
+			if (!text.contains("\"type\"") || !text.contains("GAME_MULTI_START"))
+				return;
+
+			JsonObject obj = gson.fromJson(text, JsonObject.class);
+			if (obj == null || !obj.has("type"))
+				return;
+
+			String type = obj.get("type").getAsString();
+			if (!"GAME_MULTI_START".equals(type))
+				return;
+
+			if (obj.has("slot")) {
+				int slot = obj.get("slot").getAsInt();
+				sessionSlotMap.put(target.getId(), slot);
+			}
+		} catch (Exception ignore) {}
 	}
 }

--- a/src/main/webapp/WEB-INF/views/chat/gameEmoji.jsp
+++ b/src/main/webapp/WEB-INF/views/chat/gameEmoji.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
 
-<!-- 게임 중 이모지 전용 UI (fragment) -->
+<!-- 게임 중 이모지 전용 UI -->
 <div class="emoji-game-wrap">
   <div class="player-cards">
     <div id="p1" class="player-card">

--- a/src/main/webapp/WEB-INF/views/game/multi.jsp
+++ b/src/main/webapp/WEB-INF/views/game/multi.jsp
@@ -23,7 +23,7 @@
 </style>
 
 <!-- 절대경로 로드 -->
-<link rel="stylesheet" href="/chat/emojiChat.css" />
+<link rel="stylesheet" href="${pageContext.request.contextPath}/static/chat/emojiChat.css" />
 </head>
 <body>
 	<h1>2:2 팀전 오목 게임</h1>

--- a/src/main/webapp/WEB-INF/views/game/multi.jsp
+++ b/src/main/webapp/WEB-INF/views/game/multi.jsp
@@ -304,6 +304,6 @@
 	</script>
 
     <!-- 절대경로 로드 -->
-    <script src="/chat/emojiChat.js"></script>
+    <script src="/chat/emojiChat-multi.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/game/multi.jsp
+++ b/src/main/webapp/WEB-INF/views/game/multi.jsp
@@ -6,19 +6,69 @@
 <head>
 <meta charset="UTF-8">
 <title>2 vs 2 Team Omok</title>
+
 <style>
 	canvas { border: 1px solid black; background-color: #e3c986; } /* 오목판 색상 추가 */
     #timer { font-size: 20px; font-weight: bold; margin-top: 10px; }
     #status { font-size: 18px; color: blue; font-weight: bold; margin-bottom: 5px; }
+
+    /* 보드 기준 4카드 배치만 */
+    .game-area { position: relative; display: inline-block; }
+
+    /* slot(0~3) → 위치 고정: 0=TL, 1=TR, 2=BL, 3=BR */
+    .player-card.pos-tl { position:absolute; top:-10px; left:-260px; }
+    .player-card.pos-tr { position:absolute; top:-10px; right:-260px; }
+    .player-card.pos-bl { position:absolute; bottom:-10px; left:-260px; }
+    .player-card.pos-br { position:absolute; bottom:-10px; right:-260px; }
 </style>
+
+<!-- 절대경로 로드 -->
+<link rel="stylesheet" href="/chat/emojiChat.css" />
 </head>
 <body>
 	<h1>2:2 팀전 오목 게임</h1>
     <div id="status">대기 중...</div>
-	<canvas id="board" width="450" height="450"></canvas>
+
+    <div class="game-area">
+        <canvas id="board" width="450" height="450"></canvas>
+
+        <div id="p1" class="player-card pos-tl" data-slot="0">
+          <div class="profile"></div>
+          <div class="name">P1</div>
+          <div class="bubble"></div>
+        </div>
+
+        <div id="p2" class="player-card pos-br" data-slot="3">
+          <div class="profile"></div>
+          <div class="name">P2</div>
+          <div class="bubble"></div>
+        </div>
+
+        <div id="p3" class="player-card pos-tr" data-slot="1">
+          <div class="profile"></div>
+          <div class="name">P3</div>
+          <div class="bubble"></div>
+        </div>
+
+        <div id="p4" class="player-card pos-bl" data-slot="2">
+          <div class="profile"></div>
+          <div class="name">P4</div>
+          <div class="bubble"></div>
+        </div>
+    </div>
+
 	<div id="log" style="height: 150px; overflow-y: auto; border: 1px solid #ccc; padding: 5px;"></div>
 	<div id="timer"></div>
-	
+
+    <div class="emoji-game-wrap">
+      <div class="emoji-buttons">
+        <button type="button" data-emoji="smile">🙂</button>
+        <button type="button" data-emoji="angry">😡</button>
+        <button type="button" data-emoji="clap">👏</button>
+      </div>
+      <div id="emoji-ws-status" class="ws-status">EMOJI: 준비</div>
+    </div>
+
     <button onclick="giveUp()" style="margin-top:10px; padding: 5px 10px;">기권하기</button>
 
 	<script>
@@ -26,10 +76,14 @@
 	const ctx = canvas.getContext("2d");
 	const size = 30;
     const statusDiv = document.getElementById("status");
-	
- 	// 전역 변수 초기화
-    let myIdx = -1;   // 플레이어 번호 (0~3) 저장
-    let myColor = 0;  // 1: 흑, 2: 백
+
+    /* 전역 로그인 정보 주입 */
+    window.loginUserId = "<%= (session.getAttribute("loginUserId") != null ? session.getAttribute("loginUserId") : "") %>";
+    window.loginNickname = "<%= (session.getAttribute("loginNickname") != null ? session.getAttribute("loginNickname") : "") %>";
+
+ 	/* 전역 변수 초기화 */
+    let myIdx = -1;
+    let myColor = 0;
     let isMyTurn = false;
     let gameOver = false;
     let remainsec = 0;
@@ -38,29 +92,31 @@
     drawBoard();
 
     const params = new URLSearchParams(window.location.search);
-	const playType = params.get("playType");  // "0" single | "1" multi
-	const roomId = params.get("roomId"); 
-	
+	const playType = params.get("playType");
+	const roomId = params.get("roomId");
+
 	if(!roomId) {
 		alert("roomId가 없습니다. URL에 roomId를 포함해 주세요.");
 		throw new Error("Missing roomId");
 	}
-	
-	if (playType !== "1") {
-		console.warn("playType이 multi가 아닙니다.:", playType);
-	}
-	
+
 	const wsProtocol = (location.protocol === "https:") ? "wss" : "ws";
 	const contextPath = "<%= request.getContextPath() %>";
-	const wsUrl = 
+	const wsUrl =
 		wsProtocol + "://" +
 		location.host +
 		contextPath +
 		"/game/multi/ws?roomId=" +
 		encodeURIComponent(roomId);
-	console.log("접속 시도 URL:", wsUrl);
+
 	const ws = new WebSocket(wsUrl);
-	
+
+	/* mojiChat.js가 window.singleWs를 사용 */
+	window.singleWs = ws;
+
+    window.contextPath = contextPath;
+    window.roomId = roomId;
+
 	ws.onopen = () => log("서버에 연결되었습니다. 매칭을 기다립니다...");
 	ws.onmessage = (e) => handle(JSON.parse(e.data));
     ws.onerror = (e) => console.error("WebSocket error", e);
@@ -70,41 +126,40 @@
     };
 
 	function handle(data) {
-		// 0. 플레이어 입장 대기
 		if (data.type === "MULTI_WAIT") {
 			statusDiv.innerText = data.msg;
 			log(data.msg);
 			return;
 		}
-		
-	    // 1. 게임 시작
+
 	    if (data.type === "GAME_MULTI_START") {
 	    	drawBoard();
-	    	
+
 	    	myIdx = data.slot;
 	    	myColor = data.color;
-	    	
+
+	    	/* emojiChat.js에서 내 슬롯 판단용 */
+	    	window.mySlot = myIdx;
+
             let colorName = (myColor === 1 ? "흑돌(선공)" : "백돌(후공)");
-            
-            // 사용자에게 보여줄 때만 'myIdx + 1'
             let displayIdx = myIdx + 1;
-            
+
             log("게임 시작! 당신은 " + colorName + " 팀 소속, " + displayIdx + "번째 순서입니다.");
             statusDiv.innerText = "당신은 " + colorName + " 팀 소속, " + displayIdx + "번째 순서입니다.";
+
+            /* 내 카드 이름을 즉시 닉네임으로 세팅 */
+            const myName = (window.loginNickname && window.loginNickname.trim()) ? window.loginNickname : (window.loginUserId || "나");
+            const myCardNameEl = document.querySelector(".player-card[data-slot='" + myIdx + "'] .name");
+            if (myCardNameEl) myCardNameEl.textContent = myName;
 	    }
-	    
-	    // 2. 턴 변경 알림
+
 	    if (data.type === "MULTI_TURN") {
-	    	if (gameOver) {
-	    		return;
-	    	}
-            
+	    	if (gameOver) return;
+
             isMyTurn = (data.turnIdx === myIdx);
-            
             startTimer(data.time, data.color);
-            
-            let turnColorName = (data.color === 1 ? "흑돌" : "백돌");
-            let displayTurnIdx = data.turnIdx + 1; // 상대방 번호 보여줄 때 +1
+
+            let displayTurnIdx = data.turnIdx + 1;
 
             if (isMyTurn) {
                 statusDiv.innerText = "나의 차례입니다!";
@@ -117,66 +172,62 @@
                 statusDiv.style.color = "black";
             }
 	    }
-	
-        // 3. 돌 두기
+
 	    if (data.type === "MULTI_STONE") {
 	        drawStone(data.x, data.y, data.color);
 	    }
-	    
-        // 4. 승리/패배 처리
+
 	    if (data.type === "MULTI_WIN") {
 	    	gameOver = true;
             clearInterval(timer);
 	    	let winColor = data.color;
             let msg = (winColor === 1 ? "흑돌 팀 승리!!" : "백돌 팀 승리!!");
-            
-            if (myColor === winColor) {
-                alert("승리했습니다! 축하합니다.");
-            } else {
-                alert("패배했습니다.");
-            }
+
+            if (myColor === winColor) alert("승리했습니다! 축하합니다.");
+            else alert("패배했습니다.");
+
             log(msg);
             statusDiv.innerText = msg;
-            
+
             goToRoomView();
 	    }
-	    
-        // 5. 에러/종료 메시지
+
 	    if (data.type === "error" || data.type === "GAME_OVER") {
 	    	gameOver = true;
             clearInterval(timer);
 	    	log(data.msg);
             alert(data.msg);
-            
-            if (data.type === "GAME_OVER") {
-            	goToRoomView();
-            }
+
+            if (data.type === "GAME_OVER") goToRoomView();
 	    }
+
+        // 이모지 채팅(JSON)
+        if (data.type === "EMOJI_CHAT") {
+        	if (typeof window.onEmojiChat === "function") {
+        		window.onEmojiChat(data.payload || {});
+        	}
+        	return;
+        }
 	}
-	
+
 	function giveUp() {
 		if(confirm('정말 기권하시겠습니까?')) {
             ws.send(JSON.stringify({ type: "MULTI_GIVEUP" }));
         }
 	}
-	
-	// 오목판 클릭 이벤트
+
 	canvas.addEventListener("click", e => {
-        if (ws.readyState !== WebSocket.OPEN || gameOver || !isMyTurn) {
-            return;
-        }
+        if (ws.readyState !== WebSocket.OPEN || gameOver || !isMyTurn) return;
 
         const rect = canvas.getBoundingClientRect();
         const x = Math.floor((e.clientX - rect.left) / size);
         const y = Math.floor((e.clientY - rect.top) / size);
-        
-        // 범위 체크
+
         if(x >= 0 && x < 15 && y >= 0 && y < 15) {
-            ws.send(JSON.stringify({x: x, y: y})); 
+            ws.send(JSON.stringify({x: x, y: y}));
         }
     });
-	
-	// 방 이동 함수
+
 	function goToRoomView() {
         try { ws.close(); } catch(e) {}
 
@@ -187,84 +238,72 @@
         })
         .then(res => res.json())
         .then(data => {
-            if (!data.ok) throw new Error(data.message || "update failed");
-
             setTimeout(() => {
                 location.href = contextPath + "/room?roomId=" + encodeURIComponent(roomId) + "&playType=1";
             }, 3000);
         })
         .catch(err => {
-            console.error(err);
-            // 실패해도 일단 방으로 보냄
             setTimeout(() => {
                 location.href = contextPath + "/room?roomId=" + encodeURIComponent(roomId) + "&playType=1";
             }, 3000);
         });
     }
-	
+
 	function startTimer(sec, turnColor) {
 	    clearInterval(timer);
 	    remainsec = sec;
 	    updateTimerText(turnColor, remainsec);
-        
+
 	    timer = setInterval(() => {
 	        remainsec--;
 	        updateTimerText(turnColor, remainsec);
-	        if (remainsec <= 0) {
-	            clearInterval(timer);
-	        }
+	        if (remainsec <= 0) clearInterval(timer);
 	    }, 1000);
 	}
-	
+
 	function updateTimerText(color, sec) {
 	    const timerDiv = document.getElementById("timer");
 	    let colorName = (color === 1 ? "흑돌" : "백돌");
 	    timerDiv.innerText = colorName + "턴 | 남은 시간: " + sec + "초";
-	    
-	    if (sec <= 5) {
-	        timerDiv.style.color = "red";
-	    } else {
-	        timerDiv.style.color = "black";
-	    }
+	    timerDiv.style.color = (sec <= 5) ? "red" : "black";
 	}
 
 	function drawBoard() {
-	    ctx.fillStyle = "#e3c986"; // 바닥 색
+	    ctx.fillStyle = "#e3c986";
         ctx.fillRect(0, 0, canvas.width, canvas.height);
 
 	    ctx.beginPath();
 	    ctx.lineWidth = 1;
 	    ctx.strokeStyle = "#000";
-        
+
 	    for (let i = 0; i < 15; i++) {
-            // 가로줄
 	        ctx.moveTo(size/2, size*i + size/2);
 	        ctx.lineTo(size*14 + size/2, size*i + size/2);
-            // 세로줄
 	        ctx.moveTo(size*i + size/2, size/2);
 	        ctx.lineTo(size*i + size/2, size*14 + size/2);
 	    }
 	    ctx.stroke();
 	}
-	
+
 	function drawStone(x, y, color) {
 	    ctx.beginPath();
-        // 좌표에 size/2를 더해 교차점에 돌이 찍히도록 보정
 	    ctx.arc(x * size + size/2, y * size + size/2, 12, 0, Math.PI * 2);
 	    ctx.fillStyle = (color === 1 ? "black" : "white");
 	    ctx.fill();
-        // 백돌은 테두리 필요
         if(color === 2) {
             ctx.strokeStyle = "black";
             ctx.stroke();
         }
 	}
-	
+
 	function log(msg) {
         const logDiv = document.getElementById("log");
 	    logDiv.innerHTML += msg + "<br>";
-        logDiv.scrollTop = logDiv.scrollHeight; // 자동 스크롤
+        logDiv.scrollTop = logDiv.scrollHeight;
 	}
 	</script>
+
+    <!-- 절대경로 로드 -->
+    <script src="/chat/emojiChat.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/game/multi.jsp
+++ b/src/main/webapp/WEB-INF/views/game/multi.jsp
@@ -304,6 +304,6 @@
 	</script>
 
     <!-- 절대경로 로드 -->
-    <script src="/chat/emojiChat-multi.js"></script>
+    <script src="${pageContext.request.contextPath}/static/chat/emojiChatMulti.js"></script>
 </body>
 </html>

--- a/src/main/webapp/static/chat/emojiChat.js
+++ b/src/main/webapp/static/chat/emojiChat.js
@@ -1,14 +1,13 @@
 (() => {
   const statusEl = document.querySelector("#emoji-ws-status");
 
-  const leftCard = document.querySelector("#p1");
-  const rightCard = document.querySelector("#p2");
+  const p1 = document.querySelector("#p1"); // 상대
+  const p2 = document.querySelector("#p2"); // 나
 
-  const leftNameEl = leftCard?.querySelector(".name");
-  const rightNameEl = rightCard?.querySelector(".name");
-
-  const leftBubble = leftCard?.querySelector(".bubble");
-  const rightBubble = rightCard?.querySelector(".bubble");
+  const leftNameEl  = p1 ? p1.querySelector(".name") : null;
+  const rightNameEl = p2 ? p2.querySelector(".name") : null;
+  const leftBubble  = p1 ? p1.querySelector(".bubble") : null;
+  const rightBubble = p2 ? p2.querySelector(".bubble") : null;
 
   const btns = document.querySelectorAll(".emoji-buttons button[data-emoji]");
 
@@ -37,11 +36,11 @@
   function setMyName(name) { if (rightNameEl && name) rightNameEl.textContent = name; }
   function setOppName(name) { if (leftNameEl && name) leftNameEl.textContent = name; }
 
-  /* 초기 내 닉네임(세션) */
+  /* 초기 내 닉네임 */
   setMyName(window.loginNickname || "나");
 
   /* 서버가 접속자 정보 보내면 닉네임 반영
-  payload = { userId, nickname } */
+     payload = { userId, nickname } */
   window.onSingleUser = (payload) => {
     if (!payload) return;
 
@@ -58,8 +57,8 @@
     }
   };
 
-  /*서버가 이모지 보내면: 보낸 사람 카드 위에만 띄우기
-   payload = { from, fromNick, emoji } */
+  /* 서버가 이모지 보내면: 보낸 사람 카드 위에만 띄우기
+     payload = { from, fromNick, emoji } */
   window.onEmojiChat = (payload) => {
     if (!payload) return;
 
@@ -70,14 +69,12 @@
 
     const emoji = EMOJI_MAP[key] || key;
 
-    /* 혹시 닉네임이 같이 오면 즉시 반영(상대가 먼저 이모지 보내도 이름 뜨게) */
     if (fromNick) {
       if (meId && from === meId) setMyName(fromNick);
       else setOppName(fromNick);
     }
 
     if (!meId) {
-      /* 로그인 정보가 없으면 디버깅용으로 둘 다 띄우지 말고 오른쪽만 */
       showBubble(myBubble(), emoji);
       return;
     }
@@ -93,16 +90,16 @@
       return;
     }
 
-    /* 오른쪽 플레이어 카드 = 나 */
     const emoji = EMOJI_MAP[key] || key;
+
+    /* 오른쪽 플레이어 카드 = 나 */
     showBubble(myBubble(), emoji);
 
     /* 서버로 전송 */
     ws.send("EMOJI_CHAT:" + key);
   }
-  
-  	/* 외부에서 호출 가능하도록 전역 노출 */
- 	window.sendEmoji = sendEmoji;
+
+  window.sendEmoji = sendEmoji;
 
   btns.forEach((b) => {
     b.addEventListener("click", () => sendEmoji(b.dataset.emoji));

--- a/src/main/webapp/static/chat/emojiChatMulti.js
+++ b/src/main/webapp/static/chat/emojiChatMulti.js
@@ -35,7 +35,7 @@
   window.onEmojiChat = (payload) => {
     if (!payload) return;
 
-    const slot = payload.fromSlot;
+    const slot = payload.slot;
     const key = payload.emoji;
     const emoji = EMOJI_MAP[key] || key;
 

--- a/src/main/webapp/static/chat/emojiChatMulti.js
+++ b/src/main/webapp/static/chat/emojiChatMulti.js
@@ -1,0 +1,69 @@
+(() => {
+  const statusEl = document.querySelector("#emoji-ws-status");
+
+  const EMOJI_MAP = { smile: "🙂", angry: "😡", clap: "👏" };
+
+  function setStatus(t) {
+    if (statusEl) statusEl.textContent = t;
+  }
+
+  function getCardBySlot(slot) {
+    return document.querySelector(`.player-card[data-slot='${slot}']`);
+  }
+
+  function showBubbleOnSlot(slot, emoji) {
+    const card = getCardBySlot(slot);
+    if (!card) return;
+
+    const bubble = card.querySelector(".bubble");
+    if (!bubble) return;
+
+    bubble.textContent = emoji;
+    bubble.style.display = "block";
+
+    clearTimeout(bubble._t);
+    bubble._t = setTimeout(() => {
+      bubble.style.display = "none";
+      bubble.textContent = "";
+    }, 1200);
+  }
+
+  /* 
+  서버 → 이모지 수신
+  payload = { fromSlot, emoji } 
+  */
+  window.onEmojiChat = (payload) => {
+    if (!payload) return;
+
+    const slot = payload.fromSlot;
+    const key = payload.emoji;
+    const emoji = EMOJI_MAP[key] || key;
+
+    showBubbleOnSlot(slot, emoji);
+  };
+
+  function sendEmoji(key) {
+    const ws = window.singleWs;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      setStatus("EMOJI: WS 미연결");
+      return;
+    }
+
+    const emoji = EMOJI_MAP[key] || key;
+
+    /* 내 슬롯 */
+    showBubbleOnSlot(window.mySlot, emoji);
+
+    ws.send(JSON.stringify({
+      type: "EMOJI_CHAT",
+      emoji: key
+    }));
+  }
+
+  window.sendEmoji = sendEmoji;
+
+  document.querySelectorAll(".emoji-buttons button[data-emoji]")
+    .forEach(b => b.onclick = () => sendEmoji(b.dataset.emoji));
+
+  setStatus("EMOJI: 준비됨");
+})();

--- a/src/main/webapp/static/chat/emojiChatMulti.js
+++ b/src/main/webapp/static/chat/emojiChatMulti.js
@@ -54,10 +54,7 @@
     /* 내 슬롯 */
     showBubbleOnSlot(window.mySlot, emoji);
 
-    ws.send(JSON.stringify({
-      type: "EMOJI_CHAT",
-      emoji: key
-    }));
+    ws.send("EMOJI_CHAT:" + key);
   }
 
   window.sendEmoji = sendEmoji;

--- a/src/main/webapp/static/chat/emojiChatMulti.js
+++ b/src/main/webapp/static/chat/emojiChatMulti.js
@@ -30,10 +30,11 @@
 
   /* 
   서버 → 이모지 수신
-  payload = { fromSlot, emoji } 
+  payload = { slot, emoji } 
   */
   window.onEmojiChat = (payload) => {
     if (!payload) return;
+    if (payload.slot === undefined || !payload.emoji) return;
 
     const slot = payload.slot;
     const key = payload.emoji;


### PR DESCRIPTION
## 📌 작업 내용

- 단체전(2:2) 오목 게임에 이모티콘 전용 채팅 UI 추가
- 개인전/단체전 이모티콘 채팅 로직 분리
- emojiChat.js : 개인전 전용
- emojiChat-multi.js : 단체전 전용 (slot 기반)
- 단체전 플레이어 카드 4개 구조에 맞게 이모티콘 표시 로직 구현
- 보낸 플레이어의 카드 위치에만 말풍선 표시

<br>

## 🔗 관련 이슈

- closes #102 

<br>

## 👀 리뷰 시 참고사항

- 개인전/단체전 페이지에서 서로 다른 JS 파일을 로드하도록 분리한 구조
- 단체전 이모티콘 채팅은 서버 payload의 fromSlot 값을 기준으로 카드 위치를 결정
- 기존 개인전 이모티콘 채팅 로직은 최대한 변경 없이 유지

<br>

## 💭 느낀 점

초기에 구조를 명확히 나누는 게 이후 기능 추가 시 충돌을 줄여준다는 점을 체감함

<br>

## 💻 스크린샷 (선택)

- 필요한 경우 첨부해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 멀티플레이어 방 단위 이모지 채팅 추가 — 같은 방 참가자들끼리 실시간 이모지 전송/수신 가능
  * 클라이언트용 핸들러 공개(window.onEmojiChat, window.sendEmoji)로 즉시 표시 및 전송 가능

* **UI 개선**
  * 4인용 플레이어 카드 레이아웃 도입 — 자신의 닉네임·상태·타이머가 카드에 표시
  * 슬롯별 이모지 버블 표시와 자동 숨김 동작 추가

* **수정**
  * 접속/종료 시 세션 정리 및 방 단위 메시지 라우팅 안정성 향상 (슬롯 기반 라우팅 포함)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->