### PR TITLE
[FEAT] 게임 시작 전 방장·인원 상태 검증 및 실시간 UI 반영

### DIFF
--- a/src/main/java/game/controller/GameStartController.java
+++ b/src/main/java/game/controller/GameStartController.java
@@ -59,6 +59,7 @@ public class GameStartController extends HttpServlet {
 				response.sendError(HttpServletResponse.SC_FORBIDDEN, "게임 시작 권한이 없습니다. (host만 가능)");
 				return;
 			}
+
 			int updated = roomPlayerDao.updatePlayersToInGame(roomId);
 
 			System.out.println("[GameStart] roomId=" + roomId + " updatedPlayers=" + updated);

--- a/src/main/java/lobby/controller/CreateRoomController.java
+++ b/src/main/java/lobby/controller/CreateRoomController.java
@@ -60,6 +60,8 @@ public class CreateRoomController extends HttpServlet {
 
 			String roomId = roomResult.getId();
 
+			session.setAttribute("hostUserId", hostUserId);
+
 			roomPlayerDAO.enterIfAbsent(roomResult.getId(), hostUserId);
 
 			LobbyWebSocket.broadcastRoomList();

--- a/src/main/java/room/controller/RoomController.java
+++ b/src/main/java/room/controller/RoomController.java
@@ -1,0 +1,144 @@
+package room.controller;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import com.google.gson.Gson;
+
+import room.dao.RoomPlayerDAO;
+import room.dao.RoomPlayerDAOImpl;
+import room.dto.RoomActiveCountDTO;
+
+@WebServlet("/room/*")
+public class RoomController extends HttpServlet {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Gson gson = new Gson();
+	private final RoomPlayerDAO roomPlayerDAO = new RoomPlayerDAOImpl();
+
+	@FunctionalInterface
+	private interface Handler {
+		void handle(HttpServletRequest req, HttpServletResponse res, String userId) throws Exception;
+	}
+
+	private final Map<String, Handler> getHandlers = new HashMap<>();
+
+	@Override
+	public void init() {
+		getHandlers.put("count", this::handleGetCount);
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse res)
+		throws ServletException, IOException {
+
+		String action = getAction(req);
+		if (action == null) {
+			sendJson(res, 400, ApiError.of("잘못된 요청입니다."));
+			return;
+		}
+
+		String userId = getLoginUserId(req);
+		if (userId == null || userId.isBlank()) {
+			sendJson(res, 401, ApiError.of("로그인이 필요합니다."));
+			return;
+		}
+
+		Handler handler = getHandlers.get(action);
+		if (handler == null) {
+			sendJson(res, 404, ApiError.of("존재하지 않는 API입니다."));
+			return;
+		}
+
+		try {
+			handler.handle(req, res, userId);
+		} catch (Exception e) {
+			e.printStackTrace();
+			sendJson(res, 500, ApiError.of("서버 오류가 발생했습니다."));
+		}
+	}
+
+	/**
+	 * GET /room/count?roomId=
+	 * 응답: { ok:true, data:{ roomId, totalCount, activeCount } }
+	 */
+	private void handleGetCount(HttpServletRequest req, HttpServletResponse res, String userId) throws Exception {
+		String roomId = req.getParameter("roomId");
+		if (roomId == null || roomId.isBlank()) {
+			sendJson(res, 400, ApiError.of("roomId가 필요합니다."));
+			return;
+		}
+		int activeCount = roomPlayerDAO.countActivePlayers(roomId);
+		RoomActiveCountDTO dto = new RoomActiveCountDTO(roomId, activeCount);
+		sendJson(res, 200, ApiSuccess.of(dto));
+	}
+
+	private String getAction(HttpServletRequest req) {
+		String pathInfo = req.getPathInfo();
+		if (pathInfo == null || "/".equals(pathInfo))
+			return null;
+		return pathInfo.substring(1);
+	}
+
+	private String getLoginUserId(HttpServletRequest req) {
+		HttpSession session = req.getSession(false);
+		return (session == null) ? null : (String)session.getAttribute("loginUserId");
+	}
+
+	private void sendJson(HttpServletResponse res, int status, Object body) throws IOException {
+		res.setStatus(status);
+		res.setContentType("application/json; charset=UTF-8");
+		res.getWriter().write(gson.toJson(body));
+	}
+
+	private static class ApiSuccess<T> {
+		private final boolean ok = true;
+		private final T data;
+
+		private ApiSuccess(T data) {
+			this.data = data;
+		}
+
+		public static <T> ApiSuccess<T> of(T data) {
+			return new ApiSuccess<>(data);
+		}
+
+		public boolean isOk() {
+			return ok;
+		}
+
+		public T getData() {
+			return data;
+		}
+	}
+
+	private static class ApiError {
+		private final boolean ok = false;
+		private final String message;
+
+		private ApiError(String message) {
+			this.message = message;
+		}
+
+		public static ApiError of(String message) {
+			return new ApiError(message);
+		}
+
+		public boolean isOk() {
+			return ok;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+	}
+}

--- a/src/main/java/room/controller/RoomController.java
+++ b/src/main/java/room/controller/RoomController.java
@@ -69,7 +69,7 @@ public class RoomController extends HttpServlet {
 
 	/**
 	 * GET /room/count?roomId=
-	 * 응답: { ok:true, data:{ roomId, totalCount, activeCount } }
+	 * 응답: { ok:true, data:{ roomId, activeCount } }
 	 */
 	private void handleGetCount(HttpServletRequest req, HttpServletResponse res, String userId) throws Exception {
 		String roomId = req.getParameter("roomId");

--- a/src/main/java/room/controller/ViewRoomController.java
+++ b/src/main/java/room/controller/ViewRoomController.java
@@ -34,8 +34,13 @@ public class ViewRoomController extends HttpServlet {
 			request.setAttribute("roomId", roomId);
 			request.setAttribute("playType", playType);
 
-			String userId = (session == null) ? null : (String)session.getAttribute("loginUserId");
+			String userId = (String)session.getAttribute("loginUserId");
 			String hostUserId = roomDAO.findHostUserIdByRoomId(roomId);
+
+			if (hostUserId == null) {
+				response.sendRedirect("/lobby?error=host_not_found");
+				return;
+			}
 
 			session.setAttribute("hostUserId", hostUserId);
 			session.setAttribute("userId", userId);

--- a/src/main/java/room/controller/ViewRoomController.java
+++ b/src/main/java/room/controller/ViewRoomController.java
@@ -24,17 +24,19 @@ public class ViewRoomController extends HttpServlet {
 		try {
 			String roomId = request.getParameter("roomId");
 			String playType = request.getParameter("playType");
+			HttpSession session = request.getSession(false);
 
-			if (roomId == null) {
+			if (playType == null || roomId == null || session == null) {
 				response.sendRedirect("/lobby");
 				return;
 			}
 
 			request.setAttribute("roomId", roomId);
 			request.setAttribute("playType", playType);
-			HttpSession session = request.getSession(false);
+
 			String userId = (session == null) ? null : (String)session.getAttribute("loginUserId");
 			String hostUserId = roomDAO.findHostUserIdByRoomId(roomId);
+
 			session.setAttribute("hostUserId", hostUserId);
 			session.setAttribute("userId", userId);
 

--- a/src/main/java/room/controller/ViewRoomController.java
+++ b/src/main/java/room/controller/ViewRoomController.java
@@ -7,14 +7,20 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import room.dao.RoomDAO;
+import room.dao.RoomDAOImpl;
 
 @WebServlet("/room")
 public class ViewRoomController extends HttpServlet {
 	private static final long serialVersionUID = 1L;
+	private final RoomDAO roomDAO = new RoomDAOImpl();
 
 	@Override
 	protected void doGet(HttpServletRequest request, HttpServletResponse response)
 		throws ServletException, IOException {
+
 		try {
 			String roomId = request.getParameter("roomId");
 			String playType = request.getParameter("playType");
@@ -26,6 +32,11 @@ public class ViewRoomController extends HttpServlet {
 
 			request.setAttribute("roomId", roomId);
 			request.setAttribute("playType", playType);
+			HttpSession session = request.getSession(false);
+			String userId = (session == null) ? null : (String)session.getAttribute("loginUserId");
+			String hostUserId = roomDAO.findHostUserIdByRoomId(roomId);
+			session.setAttribute("hostUserId", hostUserId);
+			session.setAttribute("userId", userId);
 
 			request.getRequestDispatcher("/WEB-INF/views/room.jsp").forward(request, response);
 			return;

--- a/src/main/java/room/dao/RoomDAO.java
+++ b/src/main/java/room/dao/RoomDAO.java
@@ -22,4 +22,11 @@ public interface RoomDAO {
 	 */
 	String getHostUserId(String roomId) throws Exception;
 
+	/**
+	* roomId로 방장 userId 조회
+	* @param roomId 방 ID
+	* @return hostUserId (없으면 null)
+	*/
+	String findHostUserIdByRoomId(String roomId) throws Exception;
+
 }

--- a/src/main/java/room/dao/RoomDAOImpl.java
+++ b/src/main/java/room/dao/RoomDAOImpl.java
@@ -169,6 +169,29 @@ public class RoomDAOImpl implements RoomDAO {
 		}
 	}
 
+	@Override
+	public String findHostUserIdByRoomId(String roomId) throws Exception {
+
+		String sql = """
+			    SELECT host_user_id
+			    FROM room
+			    WHERE id = ?
+			""";
+
+		try (
+			Connection conn = DB.getConnection();
+			PreparedStatement ps = conn.prepareStatement(sql)) {
+			ps.setString(1, roomId);
+
+			try (ResultSet rs = ps.executeQuery()) {
+				if (rs.next()) {
+					return rs.getString("host_user_id");
+				}
+				return null;
+			}
+		}
+	}
+
 	private RoomDTO mapToRoom(ResultSet rs) throws SQLException {
 		return RoomDTO.builder()
 			.id(rs.getString("id"))

--- a/src/main/java/room/dto/RoomActiveCountDTO.java
+++ b/src/main/java/room/dto/RoomActiveCountDTO.java
@@ -1,0 +1,11 @@
+package room.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RoomActiveCountDTO {
+	private String roomId;
+	private int activeCount;
+}

--- a/src/main/java/room/ws/RoomWebSocket.java
+++ b/src/main/java/room/ws/RoomWebSocket.java
@@ -148,7 +148,7 @@ public class RoomWebSocket {
 				case "ROOM_EXIT": {
 					String roomId = sessionContext.getRoomId(session);
 
-					service.onExit(session, roomId);
+					service.onExit(session, roomId, "ROOM_EXIT");
 					sessionContext.leaveRoom(session);
 
 					service.sendIfOpen(session, "ROOM_EXIT", Map.of());
@@ -215,7 +215,7 @@ public class RoomWebSocket {
 				String result = roomService.exitAndHandleHost(roomId, userId);
 				System.out.println("[RoomWS][EXIT] roomId=" + roomId + " userId=" + userId + " result=" + result);
 
-				service.onExit(session, roomId);
+				service.onExit(session, roomId, result);
 				LobbyWebSocket.broadcastRoomList();
 			}
 		} catch (Exception e) {

--- a/src/main/java/room/ws/RoomWebSocketService.java
+++ b/src/main/java/room/ws/RoomWebSocketService.java
@@ -9,6 +9,8 @@ import javax.websocket.Session;
 
 import com.google.gson.Gson;
 
+import room.dao.RoomDAO;
+import room.dao.RoomDAOImpl;
 import room.dao.RoomPlayerDAO;
 import room.dao.RoomPlayerDAOImpl;
 import room.dto.RoomPlayerDTO;
@@ -25,6 +27,7 @@ public class RoomWebSocketService {
 	private static final SessionContext sessionContext = SessionContext.getInstance();
 	private static final RoomSessionRegistry roomRegistry = RoomSessionRegistry.getInstance();
 	private final RoomPlayerDAO roomPlayerDao = new RoomPlayerDAOImpl();
+	private final RoomDAO roomDao = new RoomDAOImpl();
 
 	public void sendIfOpen(Session s, String type, Map<String, Object> payload) {
 		if (s == null || !s.isOpen())
@@ -74,22 +77,33 @@ public class RoomWebSocketService {
 			"text", text));
 	}
 
-	public void onExit(Session session, String roomId) {
+	public void onExit(Session session, String roomId, String result) {
 		if (roomId == null || roomId.isBlank())
 			return;
 
 		roomRegistry.leave(roomId, session);
 
+		if ("HOST_CHANGE".equals(result)) {
+			String hostUserId;
+			try {
+				hostUserId = roomDao.getHostUserId(roomId);
+				broadcastHostChanged(roomId, hostUserId);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+
+		}
 		broadcast(roomId, "USER_EXIT", Map.of(
 			"userId", sessionContext.getUserId(session),
 			"nickname", sessionContext.getNickname(session)));
+
 	}
 
 	/** @OnClose/@OnError 최종 정리 */
 	public void cleanup(Session session) {
 		String roomId = sessionContext.getRoomId(session);
 		if (roomId != null && !roomId.isBlank()) {
-			onExit(session, roomId);
+			onExit(session, roomId, null);
 			sessionContext.leaveRoom(session);
 		} else {
 			roomRegistry.removeFromAnyRoom(session);
@@ -109,6 +123,17 @@ public class RoomWebSocketService {
 		payload.put("playType", playType); // "0"(개인전) / "1"(팀전)
 
 		broadcast(roomId, "GAME_START", payload);
+	}
+
+	public void broadcastHostChanged(String roomId, String hostUserId) {
+		if (roomId == null || roomId.isBlank())
+			return;
+
+		Map<String, Object> payload = new HashMap<>();
+		payload.put("roomId", roomId);
+		payload.put("hostUserId", hostUserId);
+
+		broadcast(roomId, "HOST_CHANGE", payload);
 	}
 
 	private void broadcast(String roomId, String type, Map<String, Object> payload) {

--- a/src/main/java/room/ws/RoomWebSocketService.java
+++ b/src/main/java/room/ws/RoomWebSocketService.java
@@ -87,7 +87,9 @@ public class RoomWebSocketService {
 			String hostUserId;
 			try {
 				hostUserId = roomDao.getHostUserId(roomId);
-				broadcastHostChanged(roomId, hostUserId);
+				if (hostUserId != null) {
+					broadcastHostChanged(roomId, hostUserId);
+				}
 			} catch (Exception e) {
 				e.printStackTrace();
 			}

--- a/src/main/webapp/WEB-INF/views/lobby.jsp
+++ b/src/main/webapp/WEB-INF/views/lobby.jsp
@@ -44,10 +44,8 @@
   </div>
 </header>
 
-<!-- ✅ 추가 wrapper(레이아웃용). 기존 태그/클래스/아이디는 유지 -->
 <main class="lobby-layout">
 
-  <!-- 좌측: 방 목록 -->
   <section class="lobby-left">
     <h2>게임 방 목록</h2>
     <p class="subtext">참여할 게임을 선택하세요</p>

--- a/src/main/webapp/WEB-INF/views/room.jsp
+++ b/src/main/webapp/WEB-INF/views/room.jsp
@@ -16,6 +16,7 @@
         data-room-name="<c:out value='${roomName}'/>"
         data-play-type="<c:out value='${playType}'/>"
         data-host-user-id="<c:out value='${hostUserId}'/>"
+        data-user-id="<c:out value='${userId}'/>"
         >
 
     <header class="header">

--- a/src/main/webapp/WEB-INF/views/room.jsp
+++ b/src/main/webapp/WEB-INF/views/room.jsp
@@ -54,13 +54,9 @@
           <ul id="user-list" class="user-list"></ul>
        	 </div>
 		<c:if test="${sessionScope.loginUserId eq sessionScope.hostUserId}">
-		  <form id="start-form"
-		        method="post"
-		        action="${pageContext.request.contextPath}/game/start?roomId=${roomId}&playType=${playType}">
-		    <button type="submit" id="btn-start" class="btn-start">
+		  <button type="submit" id="btn-start" class="btn-start">
 		      🎯 시작하기
 		    </button>
-		  </form>
 		</c:if>
       </section>
       <section class="card">

--- a/src/main/webapp/WEB-INF/views/room.jsp
+++ b/src/main/webapp/WEB-INF/views/room.jsp
@@ -49,16 +49,18 @@
     <section class="grid">
       <section class="card side-nav">
        	 <div>
-       	  <h3>👥 참가자</h3>
+       	  <h3 >👥 참가자</h3>
           <ul id="user-list" class="user-list"></ul>
        	 </div>
-         <form id="start-form"
-        method="post"
-        action="${pageContext.request.contextPath}/game/start?roomId=${roomId}&playType=${playType}">
+		<c:if test="${sessionScope.loginUserId eq sessionScope.hostUserId}">
+		  <form id="start-form"
+		        method="post"
+		        action="${pageContext.request.contextPath}/game/start?roomId=${roomId}&playType=${playType}">
 		    <button type="submit" id="btn-start" class="btn-start">
 		      🎯 시작하기
 		    </button>
 		  </form>
+		</c:if>
       </section>
       <section class="card">
         <h3>💬 채팅</h3>

--- a/src/main/webapp/static/room/room.js
+++ b/src/main/webapp/static/room/room.js
@@ -3,7 +3,6 @@
   const roomId = pageEl?.dataset?.roomId || "";
   const roomName = pageEl?.dataset?.roomName || "";
   const userId = pageEl?.dataset?.userId || "";
-  const playType = pageEl.dataset.playType || "";
   
   
 

--- a/src/main/webapp/static/room/room.js
+++ b/src/main/webapp/static/room/room.js
@@ -2,6 +2,9 @@
   const pageEl = document.querySelector("#room-page");
   const roomId = pageEl?.dataset?.roomId || "";
   const roomName = pageEl?.dataset?.roomName || "";
+  const userId = pageEl?.dataset?.userId || "";
+  
+  
 
   const wsStatus = document.querySelector("#ws-status");
   const chatInput = document.querySelector("#chat-input"); // input
@@ -179,6 +182,31 @@
         case "ROOM_EXIT": {
           appendSystemLog("방에서 나갔습니다.");
           break;
+        }
+        
+        case "HOST_CHANGE": {
+          appendSystemLog("방장이 변경되었습니다.");
+          const p = msg.payload;
+		  const page = document.querySelector("#room-page");
+		  const roomId = page.dataset.roomId;
+		  const playType = page.dataset.playType;
+		  if (p.hostUserId === userId) {
+		    const form = document.createElement("form");
+		      form.id = "start-form";
+		      form.method = "post";
+		      form.action = `/game/start?roomId=${encodeURIComponent(roomId)}&playType=${encodeURIComponent(playType)}`;
+		
+		      const btn = document.createElement("button");
+		      btn.type = "submit";
+		      btn.id = "btn-start";
+		      btn.className = "btn-start";
+		      btn.textContent = "🎯 시작하기";
+		
+		      form.appendChild(btn);
+		      document.querySelector(".side-nav")?.appendChild(form);
+		  }
+		  console.log(p);
+		  break;
         }
 
         case "ERROR": {


### PR DESCRIPTION
## 📌 작업 내용

게임 시작 버튼 표시 및 게임 시작 요청 시점에 방장 여부와 방 인원상태를 검증하고, 방장 변경 상황을 WebSocket으로 실시간 반영하도록 개선했습니다.

1. 방 생성 시 방장 ID 세션 저장 및 시작 버튼 제어
  - 방 생성/입장 시 방장 ID를 세션에 저장
  - JSP에서 로그인 유저와 방장 ID를 비교해 방장에게만 게임 시작 버튼을 렌더링
2. 방장 변경(WebSocket) 이벤트 처리
  - 방장이 퇴장하는 경우
  - HOST_CHANGE WebSocket 이벤트 수신 시:
    - 새 방장에게만 게임 시작 버튼 동적 생성
3. 게임 시작 전 방 인원 검증 로직 추가
  - RoomController에 방 인원(active) 조회 API 추가
  - 게임 시작 버튼 클릭 시: /room/count API로 현재 active 인원 조회 
  - 인원 조건 충족 시에만 /game/start 요청 전송 불필요한 게임 시작 요청을 사전에 차단

<br>

## 🔗 관련 이슈

- closes #99 

<br>

## 👀 리뷰 시 참고사항

<br>

## 💭 느낀 점

<br>

## 💻 스크린샷 (선택)
- 방장 변경
<img width="729" height="509" alt="image" src="https://github.com/user-attachments/assets/32c56333-4e22-4f1b-ab8f-a69f916946a5" /> 

- 인원 검증
<img width="1172" height="406" alt="image" src="https://github.com/user-attachments/assets/c4ccc4cb-f367-4709-b4e8-7403d86df592" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 호스트 변경 이벤트가 방 화면에 반영되어 새 호스트에게 시작 버튼이 동적으로 생성됩니다.
  * 방 활성 인원 조회용 공개 API가 추가되어 참가자 수를 확인할 수 있습니다.

* **개선 사항**
  * 방 페이지에 사용자/호스트 정보가 세션과 페이지에 저장되어 클라이언트 동작이 개선되었습니다.
  * 게임 시작 흐름이 폼 제출에서 버튼 클릭 기반으로 변경되어, 클릭 시 참가자 수 검증 후 시작 요청이 수행됩니다.

* **버그 픽스 / 오류처리**
  * 방 조회 흐름에서 호스트 정보가 없을 경우 로비로 리디렉션하며 오류 쿼리로 안내합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->