### PR TITLE
[FEAT] 플레이어 카드에 유저 닉네임 로드 

### DIFF
--- a/src/main/webapp/WEB-INF/views/game/multi.jsp
+++ b/src/main/webapp/WEB-INF/views/game/multi.jsp
@@ -8,302 +8,359 @@
 <title>2 vs 2 Team Omok</title>
 
 <style>
-	canvas { border: 1px solid black; background-color: #e3c986; } /* 오목판 색상 추가 */
-    #timer { font-size: 20px; font-weight: bold; margin-top: 10px; }
-    #status { font-size: 18px; color: blue; font-weight: bold; margin-bottom: 5px; }
+  canvas { border: 1px solid black; background-color: #e3c986; } /* 오목판 색상 */
+  #timer { font-size: 20px; font-weight: bold; margin-top: 10px; }
+  #status { font-size: 18px; color: blue; font-weight: bold; margin-bottom: 5px; }
 
-    /* 보드 기준 4카드 배치만 */
-    .game-area { position: relative; display: inline-block; }
+  .page-wrap {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px 16px;
+  }
 
-    /* slot(0~3) → 위치 고정: 0=TL, 1=TR, 2=BL, 3=BR */
-    .player-card.pos-tl { position:absolute; top:-10px; left:-260px; }
-    .player-card.pos-tr { position:absolute; top:-10px; right:-260px; }
-    .player-card.pos-bl { position:absolute; bottom:-10px; left:-260px; }
-    .player-card.pos-br { position:absolute; bottom:-10px; right:-260px; }
+  .game-layout {
+    display: flex;
+    justify-content: center; /* 보드 중앙 */
+    align-items: flex-start;
+    gap: 24px;
+    margin-top: 10px;
+  }
+
+  .side-col {
+    width: 240px;
+    min-height: 520px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .side-col .slot-top { margin-bottom: 14px; }
+  .side-col .slot-bottom { margin-top: auto; }
+
+  .board-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .player-card {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    border: 1px solid #ddd;
+    border-radius: 14px;
+    min-width: 200px;
+    background: #fff;
+  }
+  .player-card .profile { width: 40px; height: 40px; border-radius: 50%; background: #eee; }
+  .player-card .name { font-weight: 600; }
+  .player-card .bubble {
+    position: absolute;
+    right: -14px;
+    top: -14px;
+    padding: 6px 10px;
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 12px;
+    font-size: 20px;
+    display: none;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  }
 </style>
 
-<!-- 절대경로 로드 -->
-<link rel="stylesheet" href="${pageContext.request.contextPath}/static/chat/emojiChat.css" />
+<!-- 정적 리소스 경로: /static/chat/... -->
+<link rel="stylesheet" href="<%= request.getContextPath() %>/static/chat/emojiChat.css" />
 </head>
+
 <body>
-	<h1>2:2 팀전 오목 게임</h1>
-    <div id="status">대기 중...</div>
+<div class="page-wrap">
+  <h1>2:2 팀전 오목 게임</h1>
+  <div id="status">대기 중...</div>
 
-    <div class="game-area">
-        <canvas id="board" width="450" height="450"></canvas>
-
-        <div id="p1" class="player-card pos-tl" data-slot="0">
+  <div class="game-layout">
+    <div class="side-col">
+      <div class="slot-top">
+        <div id="p1" class="player-card" data-slot="0">
           <div class="profile"></div>
           <div class="name">P1</div>
           <div class="bubble"></div>
         </div>
-
-        <div id="p2" class="player-card pos-br" data-slot="3">
-          <div class="profile"></div>
-          <div class="name">P2</div>
-          <div class="bubble"></div>
-        </div>
-
-        <div id="p3" class="player-card pos-tr" data-slot="1">
-          <div class="profile"></div>
-          <div class="name">P3</div>
-          <div class="bubble"></div>
-        </div>
-
-        <div id="p4" class="player-card pos-bl" data-slot="2">
+      </div>
+      <div class="slot-bottom">
+        <div id="p4" class="player-card" data-slot="2">
           <div class="profile"></div>
           <div class="name">P4</div>
           <div class="bubble"></div>
         </div>
-    </div>
-
-	<div id="log" style="height: 150px; overflow-y: auto; border: 1px solid #ccc; padding: 5px;"></div>
-	<div id="timer"></div>
-
-    <div class="emoji-game-wrap">
-      <div class="emoji-buttons">
-        <button type="button" data-emoji="smile">🙂</button>
-        <button type="button" data-emoji="angry">😡</button>
-        <button type="button" data-emoji="clap">👏</button>
       </div>
-      <div id="emoji-ws-status" class="ws-status">EMOJI: 준비</div>
     </div>
 
-    <button onclick="giveUp()" style="margin-top:10px; padding: 5px 10px;">기권하기</button>
+    <div class="board-col">
+      <canvas id="board" width="450" height="450"></canvas>
 
-	<script>
-	const canvas = document.getElementById("board");
-	const ctx = canvas.getContext("2d");
-	const size = 30;
-    const statusDiv = document.getElementById("status");
+      <div id="log" style="width: 450px; height: 150px; overflow-y: auto; border: 1px solid #ccc; padding: 5px; margin-top: 10px;"></div>
+      <div id="timer" style="width: 450px;"></div>
 
-    /* 전역 로그인 정보 주입 */
-    window.loginUserId = "<%= (session.getAttribute("loginUserId") != null ? session.getAttribute("loginUserId") : "") %>";
-    window.loginNickname = "<%= (session.getAttribute("loginNickname") != null ? session.getAttribute("loginNickname") : "") %>";
+      <div class="emoji-game-wrap" style="width: 450px; margin-top: 10px;">
+        <div class="emoji-buttons">
+          <button type="button" data-emoji="smile">🙂</button>
+          <button type="button" data-emoji="angry">😡</button>
+          <button type="button" data-emoji="clap">👏</button>
+        </div>
+        <div id="emoji-ws-status" class="ws-status">EMOJI: 준비</div>
+      </div>
 
- 	/* 전역 변수 초기화 */
-    let myIdx = -1;
-    let myColor = 0;
-    let isMyTurn = false;
-    let gameOver = false;
-    let remainsec = 0;
-    let timer = null;
+      <button onclick="giveUp()" style="margin-top:10px; padding: 5px 10px;">기권하기</button>
+    </div>
 
-    drawBoard();
+    <div class="side-col">
+      <div class="slot-top">
+        <div id="p3" class="player-card" data-slot="1">
+          <div class="profile"></div>
+          <div class="name">P3</div>
+          <div class="bubble"></div>
+        </div>
+      </div>
+      <div class="slot-bottom">
+        <div id="p2" class="player-card" data-slot="3">
+          <div class="profile"></div>
+          <div class="name">P2</div>
+          <div class="bubble"></div>
+        </div>
+      </div>
+    </div>
+  </div>
 
-    const params = new URLSearchParams(window.location.search);
-	const playType = params.get("playType");
-	const roomId = params.get("roomId");
+<script>
+  const canvas = document.getElementById("board");
+  const ctx = canvas.getContext("2d");
+  const size = 30;
+  const statusDiv = document.getElementById("status");
 
-	if(!roomId) {
-		alert("roomId가 없습니다. URL에 roomId를 포함해 주세요.");
-		throw new Error("Missing roomId");
-	}
+  let myIdx = -1;
+  let myColor = 0;
+  let isMyTurn = false;
+  let gameOver = false;
+  let remainsec = 0;
+  let timer = null;
 
-	const wsProtocol = (location.protocol === "https:") ? "wss" : "ws";
-	const contextPath = "<%= request.getContextPath() %>";
-	const wsUrl =
-		wsProtocol + "://" +
-		location.host +
-		contextPath +
-		"/game/multi/ws?roomId=" +
-		encodeURIComponent(roomId);
+  drawBoard();
 
-	const ws = new WebSocket(wsUrl);
+  const params = new URLSearchParams(window.location.search);
+  const playType = params.get("playType");
+  const roomId = params.get("roomId");
 
-	/* mojiChat.js가 window.singleWs를 사용 */
-	window.singleWs = ws;
+  if (!roomId) {
+    alert("roomId가 없습니다. URL에 roomId를 포함해 주세요.");
+    throw new Error("Missing roomId");
+  }
 
-    window.contextPath = contextPath;
-    window.roomId = roomId;
+  const wsProtocol = (location.protocol === "https:") ? "wss" : "ws";
+  const contextPath = "<%= request.getContextPath() %>";
+  const wsUrl = wsProtocol + "://" + location.host + contextPath + "/game/multi/ws?roomId=" + encodeURIComponent(roomId);
 
-	ws.onopen = () => log("서버에 연결되었습니다. 매칭을 기다립니다...");
-	ws.onmessage = (e) => handle(JSON.parse(e.data));
-    ws.onerror = (e) => console.error("WebSocket error", e);
-    ws.onclose = () => {
-        log("연결이 종료되었습니다.");
-        statusDiv.innerText = "연결 끊김";
-    };
+  const ws = new WebSocket(wsUrl);
 
-	function handle(data) {
-		if (data.type === "MULTI_WAIT") {
-			statusDiv.innerText = data.msg;
-			log(data.msg);
-			return;
-		}
+  /* emojiChatMulti.js에서 사용 */
+  window.singleWs = ws;
+  window.contextPath = contextPath;
+  window.roomId = roomId;
 
-	    if (data.type === "GAME_MULTI_START") {
-	    	drawBoard();
+  ws.onopen = () => log("서버에 연결되었습니다. 매칭을 기다립니다...");
+  ws.onmessage = (e) => handle(JSON.parse(e.data));
+  ws.onerror = (e) => console.error("WebSocket error", e);
+  ws.onclose = () => {
+    log("연결이 종료되었습니다.");
+    statusDiv.innerText = "연결 끊김";
+  };
 
-	    	myIdx = data.slot;
-	    	myColor = data.color;
-
-	    	/* emojiChat.js에서 내 슬롯 판단용 */
-	    	window.mySlot = myIdx;
-
-            let colorName = (myColor === 1 ? "흑돌(선공)" : "백돌(후공)");
-            let displayIdx = myIdx + 1;
-
-            log("게임 시작! 당신은 " + colorName + " 팀 소속, " + displayIdx + "번째 순서입니다.");
-            statusDiv.innerText = "당신은 " + colorName + " 팀 소속, " + displayIdx + "번째 순서입니다.";
-
-            /* 내 카드 이름을 즉시 닉네임으로 세팅 */
-            const myName = (window.loginNickname && window.loginNickname.trim()) ? window.loginNickname : (window.loginUserId || "나");
-            const myCardNameEl = document.querySelector(".player-card[data-slot='" + myIdx + "'] .name");
-            if (myCardNameEl) myCardNameEl.textContent = myName;
-	    }
-
-	    if (data.type === "MULTI_TURN") {
-	    	if (gameOver) return;
-
-            isMyTurn = (data.turnIdx === myIdx);
-            startTimer(data.time, data.color);
-
-            let displayTurnIdx = data.turnIdx + 1;
-
-            if (isMyTurn) {
-                statusDiv.innerText = "나의 차례입니다!";
-                statusDiv.style.color = "red";
-            } else if (data.color === myColor) {
-                statusDiv.innerText = "같은 팀 " + displayTurnIdx + "번의 차례입니다.";
-                statusDiv.style.color = "blue";
-            } else {
-                statusDiv.innerText = "상대방(" + displayTurnIdx + "번) 차례입니다.";
-                statusDiv.style.color = "black";
-            }
-	    }
-
-	    if (data.type === "MULTI_STONE") {
-	        drawStone(data.x, data.y, data.color);
-	    }
-
-	    if (data.type === "MULTI_WIN") {
-	    	gameOver = true;
-            clearInterval(timer);
-	    	let winColor = data.color;
-            let msg = (winColor === 1 ? "흑돌 팀 승리!!" : "백돌 팀 승리!!");
-
-            if (myColor === winColor) alert("승리했습니다! 축하합니다.");
-            else alert("패배했습니다.");
-
-            log(msg);
-            statusDiv.innerText = msg;
-
-            goToRoomView();
-	    }
-
-	    if (data.type === "error" || data.type === "GAME_OVER") {
-	    	gameOver = true;
-            clearInterval(timer);
-	    	log(data.msg);
-            alert(data.msg);
-
-            if (data.type === "GAME_OVER") goToRoomView();
-	    }
-
-        // 이모지 채팅(JSON)
-        if (data.type === "EMOJI_CHAT") {
-        	if (typeof window.onEmojiChat === "function") {
-        		window.onEmojiChat(data.payload || {});
-        	}
-        	return;
-        }
-	}
-
-	function giveUp() {
-		if(confirm('정말 기권하시겠습니까?')) {
-            ws.send(JSON.stringify({ type: "MULTI_GIVEUP" }));
-        }
-	}
-
-	canvas.addEventListener("click", e => {
-        if (ws.readyState !== WebSocket.OPEN || gameOver || !isMyTurn) return;
-
-        const rect = canvas.getBoundingClientRect();
-        const x = Math.floor((e.clientX - rect.left) / size);
-        const y = Math.floor((e.clientY - rect.top) / size);
-
-        if(x >= 0 && x < 15 && y >= 0 && y < 15) {
-            ws.send(JSON.stringify({x: x, y: y}));
-        }
-    });
-
-	function goToRoomView() {
-        try { ws.close(); } catch(e) {}
-
-        fetch(contextPath + "/room/playersToRoom", {
-            method: "POST",
-            headers: { "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8" },
-            body: "roomId=" + encodeURIComponent(roomId)
-        })
-        .then(res => res.json())
-        .then(data => {
-            setTimeout(() => {
-                location.href = contextPath + "/room?roomId=" + encodeURIComponent(roomId) + "&playType=1";
-            }, 3000);
-        })
-        .catch(err => {
-            setTimeout(() => {
-                location.href = contextPath + "/room?roomId=" + encodeURIComponent(roomId) + "&playType=1";
-            }, 3000);
-        });
+  function handle(data) {
+    if (data.type === "MULTI_WAIT") {
+      statusDiv.innerText = data.msg;
+      log(data.msg);
+      return;
     }
 
-	function startTimer(sec, turnColor) {
-	    clearInterval(timer);
-	    remainsec = sec;
-	    updateTimerText(turnColor, remainsec);
+    if (data.type === "GAME_MULTI_START") {
+      drawBoard();
 
-	    timer = setInterval(() => {
-	        remainsec--;
-	        updateTimerText(turnColor, remainsec);
-	        if (remainsec <= 0) clearInterval(timer);
-	    }, 1000);
-	}
+      myIdx = data.slot;
+      myColor = data.color;
 
-	function updateTimerText(color, sec) {
-	    const timerDiv = document.getElementById("timer");
-	    let colorName = (color === 1 ? "흑돌" : "백돌");
-	    timerDiv.innerText = colorName + "턴 | 남은 시간: " + sec + "초";
-	    timerDiv.style.color = (sec <= 5) ? "red" : "black";
-	}
+      window.mySlot = myIdx; /* 내 슬롯 */
 
-	function drawBoard() {
-	    ctx.fillStyle = "#e3c986";
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
+      const colorName = (myColor === 1 ? "흑돌(선공)" : "백돌(후공)");
+      const displayIdx = myIdx + 1;
 
-	    ctx.beginPath();
-	    ctx.lineWidth = 1;
-	    ctx.strokeStyle = "#000";
+      log("게임 시작! 당신은 " + colorName + " 팀 소속, " + displayIdx + "번째 순서입니다.");
+      statusDiv.innerText = "당신은 " + colorName + " 팀 소속, " + displayIdx + "번째 순서입니다.";
+    }
 
-	    for (let i = 0; i < 15; i++) {
-	        ctx.moveTo(size/2, size*i + size/2);
-	        ctx.lineTo(size*14 + size/2, size*i + size/2);
-	        ctx.moveTo(size*i + size/2, size/2);
-	        ctx.lineTo(size*i + size/2, size*14 + size/2);
-	    }
-	    ctx.stroke();
-	}
+    if (data.type === "MULTI_TURN") {
+      if (gameOver) return;
 
-	function drawStone(x, y, color) {
-	    ctx.beginPath();
-	    ctx.arc(x * size + size/2, y * size + size/2, 12, 0, Math.PI * 2);
-	    ctx.fillStyle = (color === 1 ? "black" : "white");
-	    ctx.fill();
-        if(color === 2) {
-            ctx.strokeStyle = "black";
-            ctx.stroke();
-        }
-	}
+      isMyTurn = (data.turnIdx === myIdx);
+      startTimer(data.time, data.color);
 
-	function log(msg) {
-        const logDiv = document.getElementById("log");
-	    logDiv.innerHTML += msg + "<br>";
-        logDiv.scrollTop = logDiv.scrollHeight;
-	}
-	</script>
+      const displayTurnIdx = data.turnIdx + 1;
 
-    <!-- 절대경로 로드 -->
-    <script src="${pageContext.request.contextPath}/static/chat/emojiChatMulti.js"></script>
+      if (isMyTurn) {
+        statusDiv.innerText = "나의 차례입니다!";
+        statusDiv.style.color = "red";
+      } else if (data.color === myColor) {
+        statusDiv.innerText = "같은 팀 " + displayTurnIdx + "번의 차례입니다.";
+        statusDiv.style.color = "blue";
+      } else {
+        statusDiv.innerText = "상대방(" + displayTurnIdx + "번) 차례입니다.";
+        statusDiv.style.color = "black";
+      }
+    }
+
+    if (data.type === "MULTI_STONE") {
+      drawStone(data.x, data.y, data.color);
+    }
+
+    if (data.type === "MULTI_WIN") {
+      gameOver = true;
+      clearInterval(timer);
+
+      const msg = (data.color === 1 ? "흑돌 팀 승리!!" : "백돌 팀 승리!!");
+      alert(myColor === data.color ? "승리했습니다! 축하합니다." : "패배했습니다.");
+      log(msg);
+      statusDiv.innerText = msg;
+
+      goToRoomView();
+    }
+
+    if (data.type === "error" || data.type === "GAME_OVER") {
+      gameOver = true;
+      clearInterval(timer);
+      log(data.msg);
+      alert(data.msg);
+
+      if (data.type === "GAME_OVER") goToRoomView();
+    }
+
+    /* 이모지 수신(JSON) */
+    if (data.type === "EMOJI_CHAT") {
+      if (typeof window.onEmojiChat === "function") {
+        window.onEmojiChat(data.payload || {});
+      }
+      return;
+    }
+    
+    /* 닉네임/슬롯 수신 */
+    if (data.type === "MULTI_USER") {
+      const p = data.payload || {};
+      const slot = p.slot;
+      const nick = p.nickname;
+
+      const card = document.querySelector(`.player-card[data-slot='${slot}']`);
+      if (card) {
+        const nameEl = card.querySelector(".name");
+        if (nameEl && nick) nameEl.textContent = nick;
+      }
+      return;
+    }
+  }
+
+  function giveUp() {
+    if (confirm("정말 기권하시겠습니까?")) {
+      ws.send(JSON.stringify({ type: "MULTI_GIVEUP" }));
+    }
+  }
+
+  canvas.addEventListener("click", (e) => {
+    if (ws.readyState !== WebSocket.OPEN || gameOver || !isMyTurn) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const x = Math.floor((e.clientX - rect.left) / size);
+    const y = Math.floor((e.clientY - rect.top) / size);
+
+    if (x >= 0 && x < 15 && y >= 0 && y < 15) {
+      ws.send(JSON.stringify({ x: x, y: y }));
+    }
+  });
+
+  function goToRoomView() {
+    try { ws.close(); } catch (e) {}
+
+    fetch(contextPath + "/room/playersToRoom", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8" },
+      body: "roomId=" + encodeURIComponent(roomId)
+    })
+      .then(res => res.json())
+      .then(data => {
+        setTimeout(() => {
+          location.href = contextPath + "/room?roomId=" + encodeURIComponent(roomId) + "&playType=1";
+        }, 3000);
+      })
+      .catch(() => {
+        setTimeout(() => {
+          location.href = contextPath + "/room?roomId=" + encodeURIComponent(roomId) + "&playType=1";
+        }, 3000);
+      });
+  }
+
+  function startTimer(sec, turnColor) {
+    clearInterval(timer);
+    remainsec = sec;
+    updateTimerText(turnColor, remainsec);
+
+    timer = setInterval(() => {
+      remainsec--;
+      updateTimerText(turnColor, remainsec);
+      if (remainsec <= 0) clearInterval(timer);
+    }, 1000);
+  }
+
+  function updateTimerText(color, sec) {
+    const timerDiv = document.getElementById("timer");
+    const colorName = (color === 1 ? "흑돌" : "백돌");
+    timerDiv.innerText = colorName + "턴 | 남은 시간: " + sec + "초";
+    timerDiv.style.color = (sec <= 5 ? "red" : "black");
+  }
+
+  function drawBoard() {
+    ctx.fillStyle = "#e3c986"; // 바닥 색
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.beginPath();
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = "#000";
+
+    for (let i = 0; i < 15; i++) {
+      ctx.moveTo(size / 2, size * i + size / 2);
+      ctx.lineTo(size * 14 + size / 2, size * i + size / 2);
+      ctx.moveTo(size * i + size / 2, size / 2);
+      ctx.lineTo(size * i + size / 2, size * 14 + size / 2);
+    }
+    ctx.stroke();
+  }
+
+  function drawStone(x, y, color) {
+    ctx.beginPath();
+    ctx.arc(x * size + size / 2, y * size + size / 2, 12, 0, Math.PI * 2);
+    ctx.fillStyle = (color === 1 ? "black" : "white");
+    ctx.fill();
+    if (color === 2) {
+      ctx.strokeStyle = "black";
+      ctx.stroke();
+    }
+  }
+
+  function log(msg) {
+    const logDiv = document.getElementById("log");
+    logDiv.innerHTML += msg + "<br>";
+    logDiv.scrollTop = logDiv.scrollHeight;
+  }
+</script>
+
+<!-- 단체전 전용 이모지 스크립트 -->
+<script src="<%= request.getContextPath() %>/static/chat/emojiChatMulti.js"></script>
+</div>
 </body>
 </html>

--- a/src/main/webapp/static/chat/emojiChatMulti.js
+++ b/src/main/webapp/static/chat/emojiChatMulti.js
@@ -1,16 +1,19 @@
 (() => {
   const statusEl = document.querySelector("#emoji-ws-status");
 
+  /* 이모지 매핑 */
   const EMOJI_MAP = { smile: "🙂", angry: "😡", clap: "👏" };
 
   function setStatus(t) {
     if (statusEl) statusEl.textContent = t;
   }
 
+  /* slot으로 카드 찾기 */
   function getCardBySlot(slot) {
     return document.querySelector(`.player-card[data-slot='${slot}']`);
   }
 
+  /* slot 카드에 이모지 버블 표시 */
   function showBubbleOnSlot(slot, emoji) {
     const card = getCardBySlot(slot);
     if (!card) return;
@@ -29,22 +32,45 @@
   }
 
   /* 
-  서버 → 이모지 수신
-  payload = { slot, emoji } 
-  */
+   * 서버 → 이모지 수신
+   * payload = { slot, emoji, from?, fromNick? }
+   */
   window.onEmojiChat = (payload) => {
     if (!payload) return;
-    if (payload.slot === undefined || !payload.emoji) return;
 
-    const slot = payload.slot;
+    const slot = payload.slot; // 서버와 키 일치
     const key = payload.emoji;
     const emoji = EMOJI_MAP[key] || key;
+
+    if (typeof slot !== "number") return;
 
     showBubbleOnSlot(slot, emoji);
   };
 
+  /* 
+   * 서버 → 슬롯/닉네임 수신
+   * payload = { slot, userId, nickname }
+   */
+  window.onMultiUser = (payload) => {
+    if (!payload) return;
+
+    const slot = payload.slot;
+    const nickname = payload.nickname;
+
+    if (typeof slot !== "number") return;
+
+    const card = getCardBySlot(slot);
+    if (!card) return;
+
+    const nameEl = card.querySelector(".name");
+    if (nameEl && nickname) {
+      nameEl.textContent = nickname;
+    }
+  };
+
+  /* 이모지 전송 */
   function sendEmoji(key) {
-    const ws = window.singleWs;
+    const ws = window.singleWs; // multi에서도 동일 소켓 변수 사용
     if (!ws || ws.readyState !== WebSocket.OPEN) {
       setStatus("EMOJI: WS 미연결");
       return;
@@ -52,16 +78,26 @@
 
     const emoji = EMOJI_MAP[key] || key;
 
-    /* 내 슬롯 */
-    showBubbleOnSlot(window.mySlot, emoji);
+    /* 내 슬롯 카드에 즉시 표시 */
+    if (typeof window.mySlot === "number") {
+      showBubbleOnSlot(window.mySlot, emoji);
+    }
 
+    /* 서버는 문자열 프로토콜을 기대함 */
     ws.send("EMOJI_CHAT:" + key);
   }
 
+  /* 외부에서 호출 가능하도록 노출 */
   window.sendEmoji = sendEmoji;
 
-  document.querySelectorAll(".emoji-buttons button[data-emoji]")
-    .forEach(b => b.onclick = () => sendEmoji(b.dataset.emoji));
+  /* 버튼 바인딩 */
+  document
+    .querySelectorAll(".emoji-buttons button[data-emoji]")
+    .forEach((b) => {
+      b.addEventListener("click", () => {
+        sendEmoji(b.dataset.emoji);
+      });
+    });
 
   setStatus("EMOJI: 준비됨");
 })();


### PR DESCRIPTION
## 📌 작업 내용

- MultiWebSocket에 플레이어 닉네임 브로드캐스트 로직 추가
- HttpSession에서 loginNickname 추출
- GAME_MULTI_START 시점에 slot 확정 후 닉네임 동기화
- 늦게 입장한 유저도 기존 플레이어 닉네임을 모두 수신하도록 처리
- MULTI_USER 메시지 수신 시 플레이어 카드 이름 업데이트

<br>

## 🔗 관련 이슈

- closes #105 

<br>

## 👀 리뷰 시 참고사항

- 아직 자신의 플레이어 카드를 우측 하단에 고정하지 않은 상태
- 이모티콘 채팅 가능
<br>

## 💭 느낀 점

- 단체전에서는 slot 확정 시점이 상태 동기화의 핵심

<br>

## 💻 스크린샷 (선택)

<img width="1026" height="802" alt="image" src="https://github.com/user-attachments/assets/cafacfd2-839a-46af-8b49-bd4e380a46a2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 멀티플레이 게임 시작 시 플레이어 닉네임 및 슬롯 정보 자동 동기화
  * 게임 진행 중 이모지 반응 기능 추가 및 실시간 표시 개선

* **개선사항**
  * 멀티플레이 게임 페이지 UI를 반응형 레이아웃으로 개편하여 플레이어 정보 및 게임보드 배치 최적화
  * 게임 상태 표시(타이머, 상태 메시지, 기권 버튼) 기능 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->