### PR TITLE
[FEAT] 비공개방 비밀번호 입력 기반 입장 처리 및 직접 URL 접근 제어

### DIFF
--- a/src/main/java/lobby/controller/CreateRoomController.java
+++ b/src/main/java/lobby/controller/CreateRoomController.java
@@ -68,6 +68,7 @@ public class CreateRoomController extends HttpServlet {
 			response.sendRedirect(
 				request.getContextPath() + "/room?roomId=" + URLEncoder.encode(roomId, StandardCharsets.UTF_8)
 					+ "&playType=" + URLEncoder.encode(playType, StandardCharsets.UTF_8));
+
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new ServletException("방 생성 실패", e);

--- a/src/main/java/lobby/controller/CreateRoomController.java
+++ b/src/main/java/lobby/controller/CreateRoomController.java
@@ -65,8 +65,11 @@ public class CreateRoomController extends HttpServlet {
 			roomPlayerDAO.enterIfAbsent(roomResult.getId(), hostUserId);
 
 			LobbyWebSocket.broadcastRoomList();
+
+			session.setAttribute("ROOM_AUTH_" + roomId, true);
+
 			response.sendRedirect(
-				request.getContextPath() + "/room?roomId=" + URLEncoder.encode(roomId, StandardCharsets.UTF_8)
+				request.getContextPath() + "/room/enter?roomId=" + URLEncoder.encode(roomId, StandardCharsets.UTF_8)
 					+ "&playType=" + URLEncoder.encode(playType, StandardCharsets.UTF_8));
 
 		} catch (Exception e) {

--- a/src/main/java/room/controller/EnterRoomController.java
+++ b/src/main/java/room/controller/EnterRoomController.java
@@ -45,23 +45,24 @@ public class EnterRoomController extends HttpServlet {
 			String roomId = request.getParameter("roomId");
 			String playType = request.getParameter("playType");
 			String roomPwd = request.getParameter("roomPwd");
-			boolean isPrivate = roomDAO.isPrivateRoom(roomId);
-			String hostUserId = roomDAO.findHostUserIdByRoomId(roomId);
 
 			if (roomId == null || roomId.isBlank() || playType == null || playType.isBlank()) {
 				response.sendRedirect(ctx + "/lobby?error=missing_room_info");
 				return;
 			}
 
-			HttpSession session = request.getSession(false);
+			boolean isPrivate = roomDAO.isPrivateRoom(roomId);
+			String hostUserId = roomDAO.findHostUserIdByRoomId(roomId);
 
+			HttpSession session = request.getSession(false);
 			String userId = (session == null) ? null : (String)session.getAttribute("loginUserId");
-			boolean isHost = userId.equals(hostUserId);
 
 			if (userId == null || userId.isBlank()) {
 				response.sendRedirect(ctx + "/lobby?error=enter_failed");
 				return;
 			}
+
+			boolean isHost = userId.equals(hostUserId);
 
 			if (isPrivate && !isHost) {
 				if (roomPwd == null || roomPwd.isBlank()) {

--- a/src/main/java/room/controller/EnterRoomController.java
+++ b/src/main/java/room/controller/EnterRoomController.java
@@ -12,6 +12,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import lobby.ws.LobbyWebSocket;
+import room.dao.RoomDAO;
+import room.dao.RoomDAOImpl;
 import room.dao.RoomPlayerDAO;
 import room.dao.RoomPlayerDAOImpl;
 
@@ -20,6 +22,7 @@ public class EnterRoomController extends HttpServlet {
 	private static final long serialVersionUID = 1L;
 
 	private final RoomPlayerDAO roomPlayerDao = new RoomPlayerDAOImpl();
+	private final RoomDAO roomDAO = new RoomDAOImpl();
 
 	@Override
 	protected void doPost(HttpServletRequest request, HttpServletResponse response)
@@ -30,8 +33,13 @@ public class EnterRoomController extends HttpServlet {
 		try {
 			String roomId = request.getParameter("roomId");
 			String playType = request.getParameter("playType");
+			String roomPwd = request.getParameter("roomPwd");
+			String isPublic = request.getParameter("isPublic");
+
+			System.out.println("isPublic: " + isPublic);
+
 			if (roomId == null || roomId.isBlank() || playType == null || playType.isBlank()) {
-				response.sendRedirect(ctx + "/lobby?error=missing_room_id");
+				response.sendRedirect(ctx + "/lobby?error=missing_room_info");
 				return;
 			}
 
@@ -40,6 +48,18 @@ public class EnterRoomController extends HttpServlet {
 			if (userId == null || userId.isBlank()) {
 				response.sendRedirect(ctx + "/lobby?error=enter_failed");
 				return;
+			}
+
+			if ("private".equals(isPublic)) {
+				if (roomPwd == null || roomPwd.isBlank()) {
+					response.sendRedirect(ctx + "/lobby?error=need_password");
+					return;
+				}
+
+				if (!roomDAO.matchRoomPassword(roomId, roomPwd)) {
+					response.sendRedirect(ctx + "/lobby?error=wrong_password");
+					return;
+				}
 			}
 
 			roomPlayerDao.enterIfAbsent(roomId, userId);

--- a/src/main/java/room/controller/ExitRoomController.java
+++ b/src/main/java/room/controller/ExitRoomController.java
@@ -32,6 +32,7 @@ public class ExitRoomController extends HttpServlet {
 
 		try {
 			roomService.exitAndHandleHost(roomId, userId);
+			session.removeAttribute("ROOM_AUTH_" + roomId);
 			System.out.println("[EXIT] ctx=" + request.getContextPath() + " roomId=" + roomId + " userId=" + userId);
 			LobbyWebSocket.broadcastRoomList();
 			response.sendRedirect(ctx + "/lobby");

--- a/src/main/java/room/controller/ViewRoomController.java
+++ b/src/main/java/room/controller/ViewRoomController.java
@@ -1,6 +1,8 @@
 package room.controller;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -28,6 +30,15 @@ public class ViewRoomController extends HttpServlet {
 
 			if (playType == null || roomId == null || session == null) {
 				response.sendRedirect("/lobby");
+				return;
+			}
+
+			boolean isPrivate = roomDAO.isPrivateRoom(roomId);
+			Boolean isRoomAuthed = (Boolean)session.getAttribute("ROOM_AUTH_" + roomId);
+
+			if (isPrivate && (isRoomAuthed == null || !isRoomAuthed)) {
+				response.sendRedirect("/room/enter?roomId=" + URLEncoder.encode(roomId, StandardCharsets.UTF_8)
+					+ "&playType=" + URLEncoder.encode(playType, StandardCharsets.UTF_8));
 				return;
 			}
 

--- a/src/main/java/room/controller/ViewRoomController.java
+++ b/src/main/java/room/controller/ViewRoomController.java
@@ -23,13 +23,15 @@ public class ViewRoomController extends HttpServlet {
 	protected void doGet(HttpServletRequest request, HttpServletResponse response)
 		throws ServletException, IOException {
 
+		String ctx = request.getContextPath();
+
 		try {
 			String roomId = request.getParameter("roomId");
 			String playType = request.getParameter("playType");
 			HttpSession session = request.getSession(false);
 
 			if (playType == null || roomId == null || session == null) {
-				response.sendRedirect("/lobby");
+				response.sendRedirect(ctx + "/lobby");
 				return;
 			}
 
@@ -37,7 +39,7 @@ public class ViewRoomController extends HttpServlet {
 			Boolean isRoomAuthed = (Boolean)session.getAttribute("ROOM_AUTH_" + roomId);
 
 			if (isPrivate && (isRoomAuthed == null || !isRoomAuthed)) {
-				response.sendRedirect("/room/enter?roomId=" + URLEncoder.encode(roomId, StandardCharsets.UTF_8)
+				response.sendRedirect(ctx + "/room/enter?roomId=" + URLEncoder.encode(roomId, StandardCharsets.UTF_8)
 					+ "&playType=" + URLEncoder.encode(playType, StandardCharsets.UTF_8));
 				return;
 			}
@@ -49,7 +51,7 @@ public class ViewRoomController extends HttpServlet {
 			String hostUserId = roomDAO.findHostUserIdByRoomId(roomId);
 
 			if (hostUserId == null) {
-				response.sendRedirect("/lobby?error=host_not_found");
+				response.sendRedirect(ctx + "/lobby?error=host_not_found");
 				return;
 			}
 

--- a/src/main/java/room/dao/RoomDAO.java
+++ b/src/main/java/room/dao/RoomDAO.java
@@ -44,4 +44,11 @@ public interface RoomDAO {
 	*/
 	boolean matchRoomPassword(String roomId, String inputPwd) throws Exception;
 
+	/**
+	 * 방이 비공개방(비밀번호가 설정된 방)인지 여부 조
+	 *
+	 * @param roomId 조회할 방 ID
+	 */
+	boolean isPrivateRoom(String roomId) throws Exception;
+
 }

--- a/src/main/java/room/dao/RoomDAO.java
+++ b/src/main/java/room/dao/RoomDAO.java
@@ -45,7 +45,7 @@ public interface RoomDAO {
 	boolean matchRoomPassword(String roomId, String inputPwd) throws Exception;
 
 	/**
-	 * 방이 비공개방(비밀번호가 설정된 방)인지 여부 조
+	 * 방이 비공개방(비밀번호가 설정된 방)인지 여부 조회
 	 *
 	 * @param roomId 조회할 방 ID
 	 */

--- a/src/main/java/room/dao/RoomDAO.java
+++ b/src/main/java/room/dao/RoomDAO.java
@@ -29,4 +29,19 @@ public interface RoomDAO {
 	*/
 	String findHostUserIdByRoomId(String roomId) throws Exception;
 
+	/**
+	* 비공개 방 비밀번호 검증
+	*
+	* @param roomId   방 ID
+	* @param inputPwd 사용자가 입력한 비밀번호 (평문)
+	*
+	* @return true  - 비밀번호 일치
+	*         false - 비밀번호 불일치 또는 존재하지 않는 방
+	*
+	* 동작 규칙
+	*  - 공개방(isPublic="0")은 호출 대상이 아님
+	*  - 비공개방(isPublic="1")에 대해서만 room_pwd와 비교
+	*/
+	boolean matchRoomPassword(String roomId, String inputPwd) throws Exception;
+
 }

--- a/src/main/java/room/dao/RoomDAOImpl.java
+++ b/src/main/java/room/dao/RoomDAOImpl.java
@@ -214,6 +214,30 @@ public class RoomDAOImpl implements RoomDAO {
 		}
 	}
 
+	@Override
+	public boolean isPrivateRoom(String roomId) throws Exception {
+
+		String query = """
+			SELECT COUNT(*)
+			FROM room
+			WHERE id = ?
+			  AND room_pwd IS NOT NULL
+			""";
+
+		try (Connection conn = DB.getConnection();
+			PreparedStatement pstmt = conn.prepareStatement(query)) {
+
+			pstmt.setString(1, roomId);
+
+			try (ResultSet rs = pstmt.executeQuery()) {
+				if (rs.next()) {
+					return rs.getInt(1) > 0;
+				}
+				return false;
+			}
+		}
+	}
+
 	private RoomDTO mapToRoom(ResultSet rs) throws SQLException {
 		return RoomDTO.builder()
 			.id(rs.getString("id"))

--- a/src/main/java/room/dao/RoomDAOImpl.java
+++ b/src/main/java/room/dao/RoomDAOImpl.java
@@ -192,6 +192,28 @@ public class RoomDAOImpl implements RoomDAO {
 		}
 	}
 
+	public boolean matchRoomPassword(String roomId, String inputPwd) throws Exception {
+		final String query = """
+			SELECT COUNT(*)
+			FROM room
+			WHERE id = ?
+			  AND is_public = '1'
+			  AND room_pwd = ?
+			""";
+
+		try (Connection conn = DB.getConnection();
+			PreparedStatement pstmt = conn.prepareStatement(query)) {
+
+			pstmt.setString(1, roomId);
+			pstmt.setString(2, inputPwd);
+
+			try (ResultSet rs = pstmt.executeQuery()) {
+				rs.next();
+				return rs.getInt(1) == 1;
+			}
+		}
+	}
+
 	private RoomDTO mapToRoom(ResultSet rs) throws SQLException {
 		return RoomDTO.builder()
 			.id(rs.getString("id"))

--- a/src/main/webapp/WEB-INF/views/room/create.jsp
+++ b/src/main/webapp/WEB-INF/views/room/create.jsp
@@ -187,11 +187,11 @@
       <div class="row">
         <label>공개 여부</label>
         <label>
-          <input type="radio" name="isPublic" value="1" checked onclick="togglePwd(false)" />
+          <input type="radio" name="isPublic" value="0" checked onclick="togglePwd(false)" />
           공개
         </label>
         <label>
-          <input type="radio" name="isPublic" value="0" onclick="togglePwd(true)" />
+          <input type="radio" name="isPublic" value="1" onclick="togglePwd(true)" />
           비공개 🔒
         </label>
       </div>

--- a/src/main/webapp/static/lobby/lobby.js
+++ b/src/main/webapp/static/lobby/lobby.js
@@ -79,10 +79,11 @@
   function toRowHtml(r) {
     const roomId = r.id ?? "";
     const roomName = r.roomName ?? "-";
-    const isPublic = (String(r.isPublic) === "1") ? "공개" : "비공개 🔒";
+    const isPublic = (String(r.isPublic) === "0") ?  "공개" : "비공개 🔒";
     const playType = (String(r.playType) === "0") ? "개인전" : "팀전";
     const current = r.currentUserCnt ?? 0;
     const total = r.totalUserCnt ?? 0;
+    const isPublicId = (String(r.isPublic) === "0") ? "public" : "private";
     
 
     const disabledAttr = IS_LOGIN ? "" : "disabled";
@@ -98,12 +99,48 @@
           <form class="enter-room-form" action="${CTX}/room/enter"" method="post">
             <input type="hidden" name="playType" value="${escapeHtml(r.playType)}" />	
 			<input type="hidden" name="roomId" value="${escapeHtml(roomId)}" />	
+			<input type="hidden" name="isPublic" value="${escapeHtml(isPublicId)}" />
             <button type="submit" ${disabledAttr} ${titleAttr}>입장</button>
           </form>
         </td>
       </tr>
     `;
   }
+  
+  document.addEventListener("submit", function (e) {
+	  const form = e.target;
+	
+	  if (!(form instanceof HTMLFormElement)) return;
+	  if (!form.classList.contains("enter-room-form")) return;
+	
+	  const isPublicEl = form.querySelector("input[name='isPublic']");
+	  const isPublic = isPublicEl ? isPublicEl.value : "public";
+	
+	  if (isPublic === "public") return;
+	
+	  e.preventDefault();
+	
+	  const pwd = prompt("비밀번호를 입력하세요");
+	  if (pwd === null) return; // 취소
+	
+	  const trimmed = pwd.trim();
+	  if (!trimmed) {
+	    alert("비밀번호를 입력해주세요.");
+	    return;
+	  }
+	
+	  let pwdInput = form.querySelector("input[name='password']");
+	  if (!pwdInput) {
+	    pwdInput = document.createElement("input");
+	    pwdInput.type = "hidden";
+	    pwdInput.name = "roomPwd";
+	    form.appendChild(pwdInput);
+	  }
+	  pwdInput.value = trimmed;
+	
+	  form.submit();
+	});
+
 
   function escapeHtml(str) {
     return String(str)

--- a/src/main/webapp/static/lobby/lobby.js
+++ b/src/main/webapp/static/lobby/lobby.js
@@ -129,7 +129,7 @@
 	    return;
 	  }
 	
-	  let pwdInput = form.querySelector("input[name='password']");
+	  let pwdInput = form.querySelector("input[name='roomPwd']");
 	  if (!pwdInput) {
 	    pwdInput = document.createElement("input");
 	    pwdInput.type = "hidden";


### PR DESCRIPTION
## 📌 작업 내용

- 비공개방 입장 시 비밀번호 검증 기반으로 접근 제어 로직 구현
- 공개방 / 비공개방 여부를 클라이언트 파라미터가 아닌 DB 기준으로 판별하도록 수정
- 비공개방의 경우 비밀번호 검증 성공 시에만 세션에 입장 인증 정보(`ROOM_AUTH_<roomId>`) 저장
- 방장(host)은 DB 기준으로 판별하여 비공개방이라도 비밀번호 입력 없이 입장 가능하도록 예외 처리
- 비공개방에 대해 직접 URL(`/room`) 접근 시 세션 인증 정보가 없으면 `/room/enter`로 리다이렉트되도록 제어

<br>

## 🔗 관련 이슈

- closes #107 

<br>

## 👀 리뷰 시 참고사항


<br>

## 💭 느낀 점

- 동적으로 세션에 인증 정보를 저장하고 제거하는 로직을 직접 구현할 수 있게 되었습니다.

<br>

## 💻 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 비공개 방 비밀번호 보호 및 인증 흐름 추가(입장 시 비밀번호 입력/검증).
  * 클라이언트에서 비공개 방 진입 시 비밀번호를 묻고 제출하는 동작 추가.

* **버그 수정 / 동작 변경**
  * 방 입장 경로가 /room? → /room/enter?로 변경되어 진입 흐름이 업데이트됨.
  * 방 생성 폼의 공개/비공개 값 전달 방식이 역전되어 기본값 해석이 변경됨.

* **기타**
  * 방별 세션 인증 상태를 설정/제거하여 입장·퇴장 시 권한 상태를 관리.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->